### PR TITLE
docs/feat: 协作配置指南+bootstrap.sh+修复队友初始化流程

### DIFF
--- a/docs/协作配置指南.md
+++ b/docs/协作配置指南.md
@@ -1,0 +1,346 @@
+# 协作配置指南
+
+**适用对象：** 新队友首次克隆仓库后的完整环境搭建说明。  
+**目标：** 从零开始，无需修改任何脚本，直接运行完整 EVB 固件构建。
+
+---
+
+## 为什么需要这份文档？
+
+本仓库使用 **Docker 构建容器** + **SmartSens 官方 SDK**（不在 Git 中，通过 gitignore 排除），两者缺一不可。直接 `git clone` 仓库后，只有源代码，还缺少：
+
+| 缺失内容 | 原因 | 来源 |
+|---|---|---|
+| `data/A1_SDK_SC132GS/` | 原厂 SDK 体积过大，不适合放入 Git | 官方 Git 仓库克隆 |
+| `a1-sdk-builder-latest.tar` | 私有 Docker 镜像，超出 Git 存储限制 | 项目负责人提供 |
+
+---
+
+## 前提条件
+
+| 工具 | 最低版本 | 检查命令 |
+|---|---|---|
+| Git | 2.30+ | `git --version` |
+| Docker Desktop (Windows/Mac) 或 Docker Engine (Linux) | 24+ | `docker --version` |
+| 可访问 `git.smartsenstech.ai` | — | 需要 SmartSens 开发者账号或 VPN |
+| 磁盘空间 | 约 20 GB | SDK 编译缓存 + Docker 镜像 |
+
+---
+
+## 完整初始化步骤
+
+### Step 1：克隆项目仓库
+
+```bash
+git clone https://github.com/GitLaughs/See-you-more-than-her.git
+cd See-you-more-than-her
+```
+
+---
+
+### Step 2：克隆 SmartSens 官方 SDK
+
+> **这是最容易遗漏的步骤。** `data/A1_SDK_SC132GS/` 在 `.gitignore` 中被排除，克隆仓库后该目录为空。
+
+```bash
+# 克隆官方 SDK 到 data/ 目录（路径固定，脚本依赖此路径）
+git clone --depth 1 \
+  https://git.smartsenstech.ai/Smartsens/A1_SDK_SC132GS.git \
+  data/A1_SDK_SC132GS
+```
+
+**说明：**
+- `--depth 1` 仅拉取最新版本，节省时间和空间
+- 目标路径必须是 `data/A1_SDK_SC132GS`（不可变更，脚本依赖此路径）
+- 需要能访问 `git.smartsenstech.ai`（SmartSens 内部 GitLab，需开发者账号）
+
+**克隆后验证：**
+
+```bash
+ls data/A1_SDK_SC132GS/smartsens_sdk/scripts/
+# 应看到: a1_sc132gs_build.sh  build_release_sdk.sh  build_dl.sh  ...
+```
+
+---
+
+### Step 3：获取 Docker 基础镜像
+
+> SmartSens 提供私有 Docker 基础镜像（含 Buildroot 工具链、交叉编译器等），通过 `.tar` 文件分发。
+
+向项目负责人索取 `a1-sdk-builder-latest.tar`，然后加载：
+
+```bash
+# 将 tar 文件放在任意位置，然后加载
+docker load -i /path/to/a1-sdk-builder-latest.tar
+
+# 验证加载成功
+docker images | grep a1-sdk-builder
+# 应显示带 latest 标签的镜像
+```
+
+**常见问题：**
+- 文件较大（约 5~10 GB），加载需要几分钟
+- 加载后镜像标签为 `a1-sdk-builder:latest`，需与 `docker/Dockerfile` 的 `FROM` 一致
+
+---
+
+### Step 4：构建加入 ROS2 的最终镜像
+
+> 在 SmartSens SDK 基础镜像之上，安装 ROS2 Jazzy 和 colcon 工具。
+
+```bash
+# 在项目根目录执行
+docker build -f docker/Dockerfile -t a1-sdk-builder:latest .
+```
+
+**预计时间：** 10~20 分钟（取决于网络速度）
+
+**构建内容：**
+- `ros-jazzy-ros-base` — ROS2 Jazzy 核心
+- `python3-colcon-common-extensions` — colcon 构建工具
+- `python3-rosdep` — ROS 依赖管理
+- 自动配置 `/etc/bash.bashrc` 加载 ROS2 环境
+
+---
+
+### Step 5：启动 Docker 容器
+
+```bash
+docker compose -f docker/docker-compose.yml up -d
+
+# 验证容器运行中
+docker ps --filter name=A1_Builder
+```
+
+**挂载关系（自动配置，无需干预）：**
+
+| 主机路径 | 容器路径 | 说明 |
+|---|---|---|
+| `./data` | `/app/data` | SmartSens SDK（Step 2 克隆的内容） |
+| `./src` | `/app/src` | C++ 源码、ROS2 工作区、Buildroot 包 |
+| `./scripts` | `/app/scripts` | 构建脚本（本仓库的 `scripts/` 目录） |
+| `./models` | `/app/models` | NPU 模型文件 |
+| `./output` | `/app/output` | 构建产物输出目录 |
+
+---
+
+### Step 6：验证容器环境
+
+```bash
+# SDK 挂载正确
+docker exec A1_Builder ls /app/data/A1_SDK_SC132GS/smartsens_sdk/scripts/
+
+# 构建脚本可访问
+docker exec A1_Builder ls /app/scripts/
+
+# ROS2 已安装
+docker exec A1_Builder bash -lc "ros2 --version"
+
+# buildroot 自定义包
+docker exec A1_Builder ls /app/src/buildroot_pkg/
+```
+
+---
+
+### Step 7：执行完整 EVB 构建
+
+```bash
+# 完整构建（含 ROS2 底盘包）— 约 12 分钟
+docker exec A1_Builder bash -lc "bash /app/scripts/build_complete_evb.sh"
+```
+
+**构建流程：**
+```
+[1] SDK 基础库（工具链、NPU 库、OSD 库）          约 6-8 分钟
+[2] ssne_face_drive_demo（人脸检测 + UART 底盘控制）  约 1-2 分钟
+[3] ROS2 工作区（serial + turn_on_wheeltec_robot 等 5 个包）  约 2 分钟
+[4] 重新打包 zImage（将应用写入 initramfs）          约 2 分钟
+```
+
+**产物：**
+```
+output/evb/
+└── 20260325_143022/          ← 时间戳目录
+    ├── zImage.smartsens-m1-evb   ← 完整固件（烧录用）
+    └── ssne_face_drive_demo      ← Demo 二进制
+```
+
+---
+
+## 一键自动化（推荐新队友使用）
+
+上述 Step 2~6 可用 `scripts/bootstrap.sh` 一键完成：
+
+```bash
+# 完整初始化
+bash scripts/bootstrap.sh --load-image /path/to/a1-sdk-builder-latest.tar
+
+# 如果基础镜像已在 Docker 中存在，仅克隆 SDK + 构建镜像 + 启动容器
+bash scripts/bootstrap.sh
+
+# 仅克隆 SDK（不操作 Docker）
+bash scripts/bootstrap.sh --sdk-only
+```
+
+---
+
+## 问题排查
+
+### 错误：`SDK 目录不存在: /app/data/A1_SDK_SC132GS/smartsens_sdk`
+
+**原因：** Step 2 未执行，SDK 未克隆。
+
+**解决：**
+```bash
+# 确认目录是否存在
+ls data/A1_SDK_SC132GS/smartsens_sdk/ 2>/dev/null || echo "目录不存在"
+
+# 重新克隆
+git clone --depth 1 \
+  https://git.smartsenstech.ai/Smartsens/A1_SDK_SC132GS.git \
+  data/A1_SDK_SC132GS
+```
+
+---
+
+### 错误：`docker: Error response from daemon: No such image: a1-sdk-builder:latest`
+
+**原因：** Step 3 未执行，Docker 基础镜像未加载。
+
+**解决：** 向项目负责人获取 `a1-sdk-builder-latest.tar` 并执行 `docker load`。
+
+---
+
+### 错误：SDK 克隆时 `Repository not found` 或 `Permission denied`
+
+**原因：** 没有访问 SmartSens 内部 GitLab 的权限。
+
+**解决：**
+1. 确认是否有 SmartSens 开发者账号
+2. 尝试通过 HTTPS 配置认证：
+   ```bash
+   git config --global credential.helper store
+   git clone https://your-username@git.smartsenstech.ai/Smartsens/A1_SDK_SC132GS.git data/A1_SDK_SC132GS
+   ```
+3. 如仍无法访问，联系项目负责人获取 SDK tar 包（离线版本）
+
+---
+
+### 错误：`build_release_sdk.sh` 中 `wget` 下载超时
+
+**原因：** SDK 初始化时需下载工具链（~1 GB）、内核源码（~300 MB）等，网络不稳定会超时。
+
+**解决：**
+```bash
+# 重新运行（wget 支持断点续传）
+docker exec A1_Builder bash -lc "bash /app/scripts/build_complete_evb.sh"
+
+# 如果反复超时，可手动进入容器预下载
+docker exec -it A1_Builder bash
+cd /app/data/A1_SDK_SC132GS/smartsens_sdk
+bash scripts/build_dl.sh    # 仅执行下载，不编译
+exit
+```
+
+---
+
+### 错误：编译 `ssne_face_drive_demo` 时 `CMake Error: The source directory ... does not appear to contain CMakeLists.txt`
+
+**原因：** `src/a1_ssne_ai_demo/` 目录不完整（Buildroot 找不到 CMakeLists.txt）。
+
+**验证：**
+```bash
+ls src/a1_ssne_ai_demo/CMakeLists.txt
+# 应该存在
+```
+
+**解决：** 确认 `git pull` 已拉取最新代码，`src/a1_ssne_ai_demo/` 中存在 `CMakeLists.txt`。
+
+---
+
+### 错误：ROS2 编译失败 `Package 'xxx' not found`
+
+**原因：** ROS2 依赖包未安装。
+
+**解决：**
+```bash
+docker exec A1_Builder bash -lc "
+  source /opt/ros/jazzy/setup.bash
+  cd /app/src/ros2_ws
+  rosdep install --from-paths src --ignore-src -r -y
+"
+```
+
+---
+
+## 目录结构速查
+
+以下是初始化完成后，与构建相关的关键路径：
+
+```
+See-you-more-than-her/          ← 项目仓库根目录
+│
+├── data/
+│   └── A1_SDK_SC132GS/         ← ⚠ 需手动克隆（gitignored）
+│       └── smartsens_sdk/
+│           ├── scripts/
+│           │   ├── build_release_sdk.sh    ← SDK 基础库构建脚本（被 build_complete_evb.sh 调用）
+│           │   └── build_dl.sh             ← 工具链/内核下载脚本
+│           ├── smart_software/
+│           │   └── package/                ← SDK 自带 Buildroot 包
+│           └── cache/                      ← 首次编译后自动生成的下载缓存
+│
+├── src/
+│   ├── a1_ssne_ai_demo/        ← 人脸检测 + 底盘控制 Demo 源码
+│   ├── buildroot_pkg/          ← 自定义 Buildroot 包（ssne_face_drive_demo）
+│   │   └── package/ssne_face_drive_demo/ssne_face_drive_demo.mk
+│   └── ros2_ws/
+│       └── src/                ← ROS2 包（serial、turn_on_wheeltec_robot 等）
+│
+├── scripts/
+│   ├── bootstrap.sh            ← 首次初始化一键脚本（本指南描述的步骤自动化）
+│   ├── build_complete_evb.sh   ← 完整 EVB 构建（在容器内执行）
+│   ├── build_incremental.sh    ← 增量构建（开发迭代用，在容器内执行）
+│   └── build_ros2_ws.sh        ← 单独 ROS2 工作区构建（在容器内执行）
+│
+├── docker/
+│   ├── Dockerfile              ← 基于 SmartSens 基础镜像，添加 ROS2 Jazzy
+│   └── docker-compose.yml      ← 容器启动配置，定义挂载关系
+│
+└── output/
+    └── evb/                    ← 构建产物（gitignored，本地生成）
+        ├── latest/             ← 软链接，指向最新构建
+        └── YYYYMMDD_HHMMSS/    ← 时间戳目录
+
+```
+
+---
+
+## 构建命令路径说明
+
+所有 `scripts/` 中的脚本均**设计为在容器内运行**，通过动态计算路径工作，无需修改。
+
+| 路径变量 | 脚本计算方式 | 容器内实际值 |
+|---|---|---|
+| `SCRIPT_DIR` | `dirname $0` | `/app/scripts` |
+| `ROOT_DIR` | `SCRIPT_DIR/..` | `/app` |
+| `SDK_DIR` | `ROOT_DIR/data/A1_SDK_SC132GS/smartsens_sdk` | `/app/data/A1_SDK_SC132GS/smartsens_sdk` |
+| `BR2_EXTERNAL` 额外路径 | 固定值 `/app/src/buildroot_pkg` | 由 docker-compose 挂载保证存在 |
+
+**关键：`BR2_EXTERNAL` 路径说明**
+
+```bash
+# build_complete_evb.sh Step 2 中的 make 命令
+make BR2_EXTERNAL=./smart_software:/app/src/buildroot_pkg ssne_face_drive_demo
+#                  ↑ SDK 自带包        ↑ 本仓库自定义包
+#                  相对于 SDK_DIR      固定容器路径（由 docker-compose 挂载）
+```
+
+- `./smart_software` — 相对于 SDK 目录的 SDK 自带扩展包
+- `/app/src/buildroot_pkg` — 本仓库中 `src/buildroot_pkg/`，由 `docker-compose.yml` 挂载到容器内固定路径
+
+---
+
+**文档版本：** v1.0  
+**最后更新：** 2026-03-25  
+**相关文档：** [编译手册](BUILD.md) | [容器操作手册](容器操作手册.md) | [快速上手指南](快速上手指南.md)

--- a/docs/快速上手指南.md
+++ b/docs/快速上手指南.md
@@ -211,6 +211,8 @@ output/
 
 ### 3.2 环境搭建步骤
 
+> ⚠️ **完整流程请参考 [协作配置指南](协作配置指南.md)**，本节为简要版。
+
 #### Step 1：克隆仓库
 
 ```bash
@@ -218,51 +220,90 @@ git clone https://github.com/GitLaughs/See-you-more-than-her.git
 cd See-you-more-than-her
 ```
 
-#### Step 2：构建 Docker 镜像
+#### Step 2：克隆 SmartSens 官方 SDK
+
+> ⚠️ **必须手动执行**：`data/A1_SDK_SC132GS/` 在 `.gitignore` 中被排除，克隆仓库后该目录为空，脚本会立即报错。
 
 ```bash
-cd docker/
-docker build -f Dockerfile -t a1-sdk-builder:latest .
+# 路径固定为 data/A1_SDK_SC132GS，不可变更
+git clone --depth 1 \
+  https://git.smartsenstech.ai/Smartsens/A1_SDK_SC132GS.git \
+  data/A1_SDK_SC132GS
+
+# 验证克隆成功
+ls data/A1_SDK_SC132GS/smartsens_sdk/scripts/
+# 应看到 build_release_sdk.sh
 ```
 
-**说明**：镜像基于 Ubuntu 24.04 Noble，包含：
-- cmake、build-essential、gcc/g++
-- ROS2 Jazzy（ros-jazzy-ros-base）
+#### Step 3：加载 Docker 基础镜像
+
+> ⚠️ **`docker/Dockerfile` 基于 SmartSens 私有基础镜像**，必须先加载 `a1-sdk-builder-latest.tar` 才能构建。
+
+向项目负责人索取 `a1-sdk-builder-latest.tar`，然后：
+
+```bash
+docker load -i /path/to/a1-sdk-builder-latest.tar
+
+# 验证加载成功
+docker images | grep a1-sdk-builder
+```
+
+#### Step 4：构建最终 Docker 镜像（添加 ROS2）
+
+```bash
+# 在项目根目录执行（不要在 docker/ 子目录中执行）
+docker build -f docker/Dockerfile -t a1-sdk-builder:latest .
+```
+
+**说明**：在 SmartSens SDK 基础镜像上额外安装：
+- ROS2 Jazzy（`ros-jazzy-ros-base`）
 - colcon 构建工具
 - rosdep 依赖管理
 
-**预计时间**：10-20 分钟（取决于网络速度）
+**预计时间**：10~20 分钟（取决于网络速度）
 
-#### Step 3：启动 Docker 容器
+#### Step 5：启动 Docker 容器
 
 ```bash
-docker compose up -d
-docker compose ps   # 确认 A1_Builder 运行中
+docker compose -f docker/docker-compose.yml up -d
+docker ps --filter name=A1_Builder   # 确认 A1_Builder 运行中
 ```
 
 **挂载关系验证**：
 ```bash
-docker exec A1_Builder ls /app/src
-docker exec A1_Builder ls /app/smartsens_sdk
+docker exec A1_Builder ls /app/scripts/
+docker exec A1_Builder ls /app/data/A1_SDK_SC132GS/smartsens_sdk/scripts/
 ```
 
-#### Step 4：验证环境
+#### Step 6：验证环境
 
 ```bash
 # 进入容器
 docker exec -it A1_Builder bash
 
 # 验证 ROS2
-source /opt/ros/jazzy/setup.bash
 ros2 --version
 
-# 验证编译工具
-cmake --version
-colcon version-check
+# 验证 SDK 路径
+ls /app/data/A1_SDK_SC132GS/smartsens_sdk/scripts/build_release_sdk.sh
 
 # 退出容器
 exit
 ```
+
+#### Step 7：执行完整 EVB 构建
+
+```bash
+# 含 ROS2 底盘包的完整构建（约 12 分钟）
+docker exec A1_Builder bash -lc "bash /app/scripts/build_complete_evb.sh"
+
+# 构建产物：
+ls output/evb/latest/
+# zImage.smartsens-m1-evb   ssne_face_drive_demo
+```
+
+> 💡 **一键自动化**：Steps 2~6 可用 `bash scripts/bootstrap.sh` 自动完成。
+> 详见 [协作配置指南](协作配置指南.md)。
 
 ### 3.3 依赖包说明
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,266 @@
+#!/bin/bash
+# bootstrap.sh — 首次克隆后的一键初始化脚本
+#
+# 用途：帮助新成员从零开始完成本地开发环境的完整初始化。
+#       包括克隆 SmartSens 官方 SDK、加载 Docker 基础镜像、构建并启动容器。
+#
+# 用法（在项目根目录，Linux/WSL/Git-Bash 中执行）：
+#   bash scripts/bootstrap.sh [选项]
+#
+# 选项：
+#   --sdk-only       仅克隆 SDK，不操作 Docker
+#   --docker-only    仅处理 Docker（跳过 SDK 克隆）
+#   --load-image <path>   指定 a1-sdk-builder-latest.tar 文件路径
+#   --skip-build     跳过 docker build（仅在已有最终镜像时使用）
+#   -h, --help       显示帮助
+#
+# 前提条件：
+#   - Git 已安装，且能访问 git.smartsenstech.ai
+#   - Docker 已安装并运行
+#   - 已获取 a1-sdk-builder-latest.tar（SmartSens SDK 基础镜像）
+#
+# 运行后，执行完整 EVB 构建：
+#   docker exec A1_Builder bash -lc "bash /app/scripts/build_complete_evb.sh"
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]-$0}")" && pwd)
+ROOT_DIR=$(cd "${SCRIPT_DIR}/.." && pwd)
+
+# ─── 颜色输出 ────────────────────────────────────────────────────────────────
+RED='\033[0;31m'; YELLOW='\033[1;33m'; GREEN='\033[0;32m'; NC='\033[0m'
+log()  { echo -e "${GREEN}[bootstrap]${NC} $*"; }
+warn() { echo -e "${YELLOW}[bootstrap] ⚠${NC}  $*"; }
+fail() { echo -e "${RED}[bootstrap] ✗${NC} $*" >&2; exit 1; }
+
+# ─── 参数解析 ────────────────────────────────────────────────────────────────
+SDK_ONLY=0
+DOCKER_ONLY=0
+LOAD_IMAGE_PATH=""
+SKIP_BUILD=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --sdk-only)       SDK_ONLY=1; shift ;;
+    --docker-only)    DOCKER_ONLY=1; shift ;;
+    --load-image)     LOAD_IMAGE_PATH="$2"; shift 2 ;;
+    --skip-build)     SKIP_BUILD=1; shift ;;
+    -h|--help)
+      grep '^#' "$0" | head -28 | sed 's/^# \{0,2\}//'
+      exit 0 ;;
+    *) fail "未知选项: $1" ;;
+  esac
+done
+
+echo "============================================================"
+echo "  A1 Vision Robot Stack — 首次初始化"
+echo "============================================================"
+echo "项目根目录: ${ROOT_DIR}"
+echo ""
+
+# ════════════════════════════════════════════════════════════════
+# STEP 1：克隆 SmartSens 官方 SDK
+# ════════════════════════════════════════════════════════════════
+SDK_TARGET="${ROOT_DIR}/data/A1_SDK_SC132GS"
+SDK_MARKER="${SDK_TARGET}/smartsens_sdk/scripts/build_release_sdk.sh"
+SDK_GIT_URL="https://git.smartsenstech.ai/Smartsens/A1_SDK_SC132GS.git"
+
+if [[ ${DOCKER_ONLY} -eq 0 ]]; then
+  echo "── Step 1: SmartSens 官方 SDK ──────────────────────────────"
+
+  if [[ -f "${SDK_MARKER}" ]]; then
+    log "SDK 已存在：${SDK_TARGET}"
+    log "  跳过克隆（如需重新克隆，请先删除该目录）"
+  else
+    log "正在克隆 SDK → ${SDK_TARGET}"
+    log "  来源: ${SDK_GIT_URL}"
+    log "  注意: --depth 1 仅拉取最新版本，节省空间和时间（约 500MB~2GB）"
+    echo ""
+
+    mkdir -p "${ROOT_DIR}/data"
+
+    # 如果目录存在但不完整，清理后重新克隆
+    if [[ -d "${SDK_TARGET}" ]]; then
+      warn "发现不完整的 SDK 目录，清理中..."
+      rm -rf "${SDK_TARGET}"
+    fi
+
+    git clone --depth 1 "${SDK_GIT_URL}" "${SDK_TARGET}" \
+      || fail "SDK 克隆失败。请检查：
+  1. 是否能访问 git.smartsenstech.ai（VPN/内网）
+  2. Git 账号权限（需要 SmartSens 开发者账号）
+  3. 网络连接是否正常"
+
+    log "✓ SDK 克隆成功"
+  fi
+
+  # 验证 SDK 结构
+  echo ""
+  log "验证 SDK 目录结构..."
+  for check_path in \
+    "${SDK_TARGET}/smartsens_sdk" \
+    "${SDK_TARGET}/smartsens_sdk/scripts/build_release_sdk.sh" \
+    "${SDK_TARGET}/smartsens_sdk/smart_software"; do
+    if [[ -e "${check_path}" ]]; then
+      log "  ✓ ${check_path##${ROOT_DIR}/}"
+    else
+      fail "SDK 结构不完整，缺少: ${check_path##${ROOT_DIR}/}
+  请尝试重新克隆或联系项目负责人。"
+    fi
+  done
+  echo ""
+fi
+
+if [[ ${SDK_ONLY} -eq 1 ]]; then
+  log "✓ SDK 初始化完成（--sdk-only 模式，跳过 Docker）"
+  exit 0
+fi
+
+# ════════════════════════════════════════════════════════════════
+# STEP 2：Docker 环境检查
+# ════════════════════════════════════════════════════════════════
+echo "── Step 2: Docker 环境检查 ─────────────────────────────────"
+
+if ! command -v docker &>/dev/null; then
+  fail "Docker 未安装。请先安装 Docker Desktop（Windows/Mac）或 Docker Engine（Linux）。"
+fi
+
+if ! docker info &>/dev/null; then
+  fail "Docker 未运行。请先启动 Docker Desktop 或 Docker 守护进程。"
+fi
+
+log "✓ Docker 就绪：$(docker version --format '{{.Server.Version}}' 2>/dev/null || echo '版本未知')"
+echo ""
+
+# ════════════════════════════════════════════════════════════════
+# STEP 3：获取/验证 Docker 基础镜像
+# ════════════════════════════════════════════════════════════════
+echo "── Step 3: SmartSens SDK Docker 基础镜像 ───────────────────"
+
+BASE_IMAGE="a1-sdk-builder:latest"
+
+if docker image inspect "${BASE_IMAGE}" &>/dev/null; then
+  log "✓ 基础镜像已存在：${BASE_IMAGE}"
+else
+  warn "基础镜像 ${BASE_IMAGE} 不存在"
+
+  # 尝试从指定 tar 加载
+  if [[ -n "${LOAD_IMAGE_PATH}" ]]; then
+    if [[ ! -f "${LOAD_IMAGE_PATH}" ]]; then
+      fail "指定的镜像文件不存在: ${LOAD_IMAGE_PATH}"
+    fi
+    log "从 tar 加载基础镜像: ${LOAD_IMAGE_PATH}"
+    docker load -i "${LOAD_IMAGE_PATH}" \
+      || fail "docker load 失败，请确认 tar 文件完整"
+    log "✓ 基础镜像加载成功"
+
+  # 尝试在常见位置自动查找 tar
+  elif [[ -f "${ROOT_DIR}/a1-sdk-builder-latest.tar" ]]; then
+    warn "在项目根目录发现 a1-sdk-builder-latest.tar，正在加载..."
+    docker load -i "${ROOT_DIR}/a1-sdk-builder-latest.tar" \
+      || fail "docker load 失败"
+    log "✓ 基础镜像加载成功"
+
+  else
+    fail "缺少 SmartSens SDK Docker 基础镜像。
+  
+  请通过以下方式之一获取：
+    A) 向项目负责人索取 a1-sdk-builder-latest.tar，然后：
+       docker load -i /path/to/a1-sdk-builder-latest.tar
+    
+    B) 再次运行本脚本并指定路径：
+       bash scripts/bootstrap.sh --load-image /path/to/a1-sdk-builder-latest.tar
+  
+  获取后请重新运行: bash scripts/bootstrap.sh"
+  fi
+fi
+echo ""
+
+# ════════════════════════════════════════════════════════════════
+# STEP 4：构建最终 Docker 镜像（加入 ROS2 Jazzy）
+# ════════════════════════════════════════════════════════════════
+echo "── Step 4: 构建 A1_Builder 镜像（添加 ROS2 Jazzy）─────────"
+
+if [[ ${SKIP_BUILD} -eq 1 ]]; then
+  log "跳过 docker build（--skip-build）"
+else
+  log "从 docker/Dockerfile 构建最终镜像（约 10-20 分钟，需要网络）..."
+  log "此步骤会在 SmartSens SDK 基础上安装 ROS2 Jazzy + colcon 工具"
+  echo ""
+  docker build \
+    -f "${ROOT_DIR}/docker/Dockerfile" \
+    -t "a1-sdk-builder:latest" \
+    "${ROOT_DIR}" \
+    || fail "docker build 失败。
+  常见原因：
+  1. 网络问题（ROS2 包无法下载） — 检查代理或镜像源配置
+  2. 磁盘空间不足（需要约 10GB）
+  3. 基础镜像与 Dockerfile 不兼容"
+
+  log "✓ 镜像构建成功"
+fi
+echo ""
+
+# ════════════════════════════════════════════════════════════════
+# STEP 5：启动 Docker 容器
+# ════════════════════════════════════════════════════════════════
+echo "── Step 5: 启动 A1_Builder 容器 ────────────────────────────"
+
+# 清理旧容器（如果存在）
+if docker ps -a --format '{{.Names}}' | grep -q '^A1_Builder$'; then
+  warn "发现已有 A1_Builder 容器，先停止并删除..."
+  docker rm -f A1_Builder 2>/dev/null || true
+fi
+
+log "启动容器..."
+docker compose -f "${ROOT_DIR}/docker/docker-compose.yml" up -d \
+  || fail "容器启动失败。请检查 docker-compose.yml 配置。"
+
+# 等待容器就绪
+sleep 2
+if ! docker ps --format '{{.Names}}' | grep -q '^A1_Builder$'; then
+  fail "容器启动后未检测到 A1_Builder 运行"
+fi
+log "✓ 容器 A1_Builder 已运行"
+echo ""
+
+# ════════════════════════════════════════════════════════════════
+# STEP 6：容器内环境验证
+# ════════════════════════════════════════════════════════════════
+echo "── Step 6: 验证容器内环境 ──────────────────────────────────"
+
+verify() {
+  local desc="$1"; local cmd="$2"
+  if docker exec A1_Builder bash -lc "${cmd}" &>/dev/null; then
+    log "  ✓ ${desc}"
+  else
+    warn "  ✗ ${desc} — 请手动确认"
+  fi
+}
+
+verify "SDK 目录挂载"   "test -d /app/data/A1_SDK_SC132GS/smartsens_sdk"
+verify "构建脚本挂载"   "test -f /app/scripts/build_complete_evb.sh"
+verify "ROS2 Jazzy"    "test -f /opt/ros/jazzy/setup.bash"
+verify "colcon 工具"   "which colcon"
+verify "buildroot_pkg" "test -f /app/src/buildroot_pkg/external.desc"
+echo ""
+
+# ════════════════════════════════════════════════════════════════
+# 完成
+# ════════════════════════════════════════════════════════════════
+echo "============================================================"
+log "✓ 初始化完成！"
+echo ""
+echo "下一步操作："
+echo ""
+echo "  # 完整 EVB 构建（含 ROS2 底盘包，约 12 分钟）："
+echo "  docker exec A1_Builder bash -lc \"bash /app/scripts/build_complete_evb.sh\""
+echo ""
+echo "  # 快速构建（跳过 ROS2，约 8 分钟）："
+echo "  docker exec A1_Builder bash -lc \"bash /app/scripts/build_complete_evb.sh --skip-ros\""
+echo ""
+echo "  # 查看构建产物："
+echo "  ls output/evb/latest/"
+echo ""
+echo "  详细说明: docs/协作配置指南.md"
+echo "============================================================"


### PR DESCRIPTION
## 问题描述

队友 git clone 仓库后直接运行编译脚本，报错无法运行。

### 根本原因

| 问题 | 影响 |
|---|---|
| data/A1_SDK_SC132GS/ 被 gitignored，文档缺少 SDK 克隆步骤 | build_complete_evb.sh 立即报错: SDK 目录不存在 |
| 快速上手指南 docker build 缺少前置的 docker load 步骤 | 无法构建镜像（基础镜像 a1-sdk-builder:latest 不存在）|
| docker build 命令在 docker/ 子目录执行，构建上下文错误 | 无法复制 src/buildroot_pkg 等文件 |
| 验证命令引用 /app/smartsens_sdk（不存在的容器路径） | 误导排查方向 |

## 变更内容

### 新增 docs/协作配置指南.md

完整 7 步初始化流程，包含：SDK 克隆命令（路径固定要求说明）、Docker 基础镜像获取和加载方式、完整挂载关系表格、5 种常见错误排查、构建路径变量速查表（解释 BR2_EXTERNAL 双路径原理）

### 新增 scripts/bootstrap.sh

一键自动化初始化脚本，自动完成：SDK 克隆（已存在时跳过）、Docker 基础镜像加载、镜像构建（添加 ROS2 Jazzy 层）、容器启动、6 项环境验证

### 修复 docs/快速上手指南.md 3.2 节

- 新增 Step 2：克隆官方 SDK（git clone --depth 1 https://git.smartsenstech.ai/...）
- 新增 Step 3：加载 Docker 基础镜像（docker load）
- 修正 docker build 命令（在项目根目录执行）
- 修复验证命令（/app/smartsens_sdk 改为 /app/data/A1_SDK_SC132GS/smartsens_sdk）

## 验证

队友现在只需 4 步即可完成完整构建，无需修改任何脚本：

1. git clone https://github.com/GitLaughs/See-you-more-than-her.git
2. git clone --depth 1 https://git.smartsenstech.ai/Smartsens/A1_SDK_SC132GS.git data/A1_SDK_SC132GS
3. bash scripts/bootstrap.sh --load-image /path/to/a1-sdk-builder-latest.tar
4. docker exec A1_Builder bash -lc "bash /app/scripts/build_complete_evb.sh"
