### PR TITLE
feat: 1280x720→640x360 推理管道 + 底盘控制 UI + A1↔STM32 联通测试

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
 a1-sdk-builder-latest.tar
-data/A1_SDK_SC132GS/
-src/app_demo/
 data/yolov8_dataset/raw/
 output/
 src/ros2_ws/build/

--- a/tools/aurora/aurora_capture.py
+++ b/tools/aurora/aurora_capture.py
@@ -114,10 +114,8 @@ def open_camera(device_id: int) -> Optional[cv2.VideoCapture]:
 def read_grayscale_frame(cap: cv2.VideoCapture) -> Optional[np.ndarray]:
     """读取一帧灰度图像
 
-    确保输出为单通道 640×360 灰度图，无论摄像头驱动如何解析。
-    EVB 固件更新后，摄像头直接输出 640×360 Y8；
-    固件未更新时，YUYV 竖屏 720×1280 经 DirectShow 汇报为 360(W)×1280(H)，
-    此时自动旋转 90° 并缩放到 640×360。
+    EVB 固件已更新，摄像头直接输出 640×360 Y8 灰度帧。
+    如实际尺寸不符，执行缩放兜底（不旋转）。
     """
     ret, frame = cap.read()
     if not ret:
@@ -130,13 +128,6 @@ def read_grayscale_frame(cap: cv2.VideoCapture) -> Optional[np.ndarray]:
     # 已是目标尺寸，直接返回
     if frame.shape == (CAMERA_HEIGHT, CAMERA_WIDTH):
         return frame
-
-    # 360(W)×1280(H) — SDK 未更新时的竖屏 YUYV 兼容帧格式
-    # 传感器竖屏 720(W)×1280(H)，YUYV 宏像素使 DirectShow 汇报宽度减半 → 360×1280
-    # 旋转 90° 顺时针：(H=1280, W=360) → (H=360, W=1280)，再缩放到 640×360
-    if frame.shape == (1280, 360):
-        frame = cv2.rotate(frame, cv2.ROTATE_90_CLOCKWISE)
-        return cv2.resize(frame, (CAMERA_WIDTH, CAMERA_HEIGHT))
 
     # 通用兜底：直接缩放
     return cv2.resize(frame, (CAMERA_WIDTH, CAMERA_HEIGHT))

--- a/tools/aurora/aurora_companion.py
+++ b/tools/aurora/aurora_companion.py
@@ -96,10 +96,7 @@ def _read_gray(cap: cv2.VideoCapture) -> Optional[np.ndarray]:
         frame = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
     if frame.shape == (CAMERA_HEIGHT, CAMERA_WIDTH):
         return frame
-    # 360(W)×1280(H): SDK 未更新时的 YUYV 竖屏封装格式—旋转 90° 顺时针再缩放
-    if frame.shape == (1280, 360):
-        frame = cv2.rotate(frame, cv2.ROTATE_90_CLOCKWISE)
-        return cv2.resize(frame, (CAMERA_WIDTH, CAMERA_HEIGHT))
+    # 尺寸不符时直接缩放（EVB 固件已更新，不再有竖屏旋转需求）
     return cv2.resize(frame, (CAMERA_WIDTH, CAMERA_HEIGHT))
 
 

--- a/tools/aurora/chassis_comm.py
+++ b/tools/aurora/chassis_comm.py
@@ -334,3 +334,48 @@ def raw_send():
         "ts": time.strftime("%H:%M:%S"),
     })
     return jsonify({"success": True, "bytes_sent": len(raw)})
+
+
+@chassis_bp.route("/ping", methods=["POST"])
+def ping():
+    """A1 ↔ STM32 联通测试
+    发送一个零速度指令帧，等待最多 500ms，若收到有效遥测帧则判断为连通。
+    返回: {"success": bool, "connected": bool, "frame_tx": str, "telemetry": ...}
+    """
+    import time as _time
+    frame = build_cmd(0, 0, 0)
+    with _ser_lock:
+        if _ser is None or not _ser.is_open:
+            return jsonify({"success": False, "error": "串口未连接"})
+        try:
+            _ser.write(frame)
+        except Exception as e:
+            return jsonify({"success": False, "error": str(e)})
+
+    _tx_log.appendleft({
+        "hex": frame.hex(" ").upper(),
+        "vx": 0, "vy": 0, "vz": 0, "cmd": 0,
+        "ts": _time.strftime("%H:%M:%S"),
+    })
+
+    # 等待遥测数据（RX 线程持续接收，最多等 600ms）
+    deadline = _time.monotonic() + 0.6
+    while _time.monotonic() < deadline:
+        with _ser_lock:
+            tele = dict(_telemetry) if _telemetry else None
+        if tele is not None:
+            return jsonify({
+                "success": True,
+                "connected": True,
+                "frame_tx": frame.hex(" ").upper(),
+                "telemetry": tele,
+            })
+        _time.sleep(0.05)
+
+    # 超时：发送成功但未收到遥测（单向连通或遥测线未接）
+    return jsonify({
+        "success": True,
+        "connected": False,
+        "frame_tx": frame.hex(" ").upper(),
+        "note": "发送成功，未收到 STM32 遥测帧（请检查 RX 接线）",
+    })

--- a/tools/aurora/templates/companion_ui.html
+++ b/tools/aurora/templates/companion_ui.html
@@ -273,7 +273,7 @@ select option{background:var(--surface);}
       <div class="card">
         <div class="card-head">
           <span>实时预览</span>
-          <span style="color:var(--green);font-size:.9em">1280 × 720</span>
+          <span style="color:var(--green);font-size:.9em">采集 1280 × 720 · 推理 640 × 360</span>
         </div>
         <div class="preview-wrap">
           <img id="stream" src="/video_feed" alt="camera"
@@ -327,7 +327,8 @@ select option{background:var(--surface);}
         <div class="card-body">
           <table class="info-tbl">
             <tr><td>传感器</td><td>SC132GS (USB-C)</td></tr>
-            <tr><td>原始分辨率</td><td>1280 × 720 灰度</td></tr>
+            <tr><td>原始分辨率</td><td>1280 × 720 灰度 (采集)</td></tr>
+            <tr><td>推理输入</td><td>640 × 360 (缩放后)</td></tr>
             <tr><td>训练裁剪</td><td>640 × 360 (16:9)</td></tr>
             <tr><td>输出格式</td><td>PNG 8-bit 灰度</td></tr>
             <tr><td>输出目录</td><td>{{ output_dir }}</td></tr>
@@ -572,6 +573,29 @@ select option{background:var(--surface);}
       </div>
     </div>
 
+    <!-- ── A1 ↔ STM32 联通测试 ── -->
+    <div class="card chs-debug">
+      <div class="card-head">
+        <span>A1 ↔ STM32 联通测试</span>
+        <span id="pingBadge" style="font-size:.78em;padding:2px 8px;border-radius:10px;background:var(--surface2);color:var(--muted);">未测试</span>
+      </div>
+      <div class="card-body">
+        <div style="font-size:.75em;color:var(--muted);margin-bottom:8px;">
+          发送零速度指令帧，最多等待 600ms，验证 A1→STM32 控制链路是否畅通，并检查遥测回传。
+        </div>
+        <div style="display:flex;gap:8px;margin-bottom:8px;">
+          <button class="btn btn-blue" style="flex:1;" id="pingBtn" onclick="runPingTest()">
+            🔍 发起联通测试
+          </button>
+        </div>
+        <pre id="pingResult" style="background:var(--surface2);border-radius:6px;padding:8px 10px;font-size:.72em;color:var(--text);font-family:monospace;white-space:pre-wrap;min-height:40px;margin:0;"></pre>
+        <div class="divider"></div>
+        <div style="font-size:.72em;color:var(--muted);">
+          ⚠️ 测试前请先完成串口连接 · TX 单向连通也视为部分成功
+        </div>
+      </div>
+    </div>
+
     <!-- ── 通信日志 ── -->
     <div class="card chs-debug">
       <div class="card-head">
@@ -764,6 +788,56 @@ function emergencyStop() {
     toast(d.success ? '⬛ 急停' : '✗ '+d.error, d.success ? 'info' : 'err');
   });
 }
+
+// ── A1 ↔ STM32 联通测试 ────────────────────────────────────────────────────
+function runPingTest() {
+  const btn = document.getElementById('pingBtn');
+  const badge = document.getElementById('pingBadge');
+  const result = document.getElementById('pingResult');
+  btn.disabled = true;
+  badge.textContent = '测试中…';
+  badge.style.background = 'var(--amber)'; badge.style.color = '#000';
+  result.textContent = '正在发送零速度帧并等待遥测回应…';
+
+  fetch('/api/chassis/ping', {method:'POST'})
+  .then(r=>r.json())
+  .then(d=>{
+    btn.disabled = false;
+    if (!d.success) {
+      badge.textContent = '失败';
+      badge.style.background = 'var(--red)'; badge.style.color = '#fff';
+      result.textContent = '✗ 错误: ' + (d.error || '未知');
+      return;
+    }
+    if (d.connected) {
+      badge.textContent = '双向连通 ✓';
+      badge.style.background = 'var(--green)'; badge.style.color = '#fff';
+      const t = d.telemetry;
+      result.textContent =
+        `✅ A1 → STM32 发送成功\n✅ STM32 → A1 收到遥测帧\n\n` +
+        `发送帧: ${d.frame_tx}\n\n` +
+        `遥测数据:\n` +
+        `  速度  Vx=${t.vx} Vy=${t.vy} Vz=${t.vz} mm/s\n` +
+        `  加速度 Ax=${t.ax?.toFixed(3)} Ay=${t.ay?.toFixed(3)} Az=${t.az?.toFixed(3)} m/s²\n` +
+        `  陀螺仪 Gx=${t.gx?.toFixed(3)} Gy=${t.gy?.toFixed(3)} Gz=${t.gz?.toFixed(3)} rad/s\n` +
+        `  电池   ${t.volt?.toFixed(2)} V`;
+    } else {
+      badge.textContent = '单向连通';
+      badge.style.background = 'var(--amber)'; badge.style.color = '#000';
+      result.textContent =
+        `⚠️ A1 → STM32 发送成功，未收到遥测回传\n\n` +
+        `发送帧: ${d.frame_tx}\n\n` +
+        (d.note || '请检查 STM32→A1 (GPIO_PIN_2 / RX) 接线是否正确');
+    }
+  })
+  .catch(e => {
+    btn.disabled = false;
+    badge.textContent = '错误';
+    badge.style.background = 'var(--red)'; badge.style.color = '#fff';
+    result.textContent = '✗ 网络错误: ' + e;
+  });
+}
+
 
 function quickMove(vx, vy, vz) {
   if (!chsConnected) { toast('请先连接串口', 'err'); return; }


### PR DESCRIPTION
## 变更概述

将人脸检测推理管道从旧的**裁剪方案**升级为**全分辨率缩放方案**，并集成底盘控制调试界面。

---

## SDK C++ 源码 (data/A1_SDK_SC132GS)

### 废弃旧裁剪参数
- 移除 \crop_shape {720, 540}\
- 移除 \crop_offset_y 370\
- 移除 \det_shape {640, 480}\

### 新管道
\\\
SC132GS → 1280×720 Y8 (全帧采集)
        → RunAiPreprocessPipe 硬件缩放
        → 640×360 Y8 SSNE 推理 (det_shape)
        → OSD 叠加 (坐标系 1280×720, scale=2×)
\\\

- **\src/pipeline_image.cpp\**: \OnlineSetCrop\ 改为无裁剪full 1280×720
- **\demo_face.cpp\**: img 720×1280 → 1280×720, det_shape {640,480} → {640,360}, 移除坐标偏移
- **新增 \src/chassis_controller.cpp\** / **\include/chassis_controller.hpp\**: WHEELTEC C50X UART 控制 (11字节帧, 115200baud)
- **\cmake_config/Paths.cmake\** / **\CMakeLists.txt\**: 链接 libuart_api / libgpio_api

---

## Python 工具 (	ools/aurora)

- **\urora_capture.py\**: 移除 360×1280 旋转兜底代码 (EVB 固件已更新，直接输出 1280×720)
- **\urora_companion.py\**: 同上
- **\chassis_comm.py\**: 新增 \/api/chassis/ping\ 联通测试路由（发送零速帧，等待遥测回传验证双向链路）

---

## 前端 (	ools/aurora/templates/companion_ui.html)

- 预览标题：\1280 × 720\ → \采集 1280×720 · 推理 640×360\
- 设备信息表新增「推理输入」行
- **新增「A1 ↔ STM32 联通测试」卡片**：发起测试 → 显示双向/单向连通结果及遥测数据

---

## 配置

- **\.gitignore\**: 移除 \data/A1_SDK_SC132GS/\ 排除规则，将 SDK 源码纳入版本管理