### PR TITLE
fix+feat(aurora): DirectShow capture thread fix + A1 Viewer display tool

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,14 +1,4 @@
 {
-  "python.defaultInterpreterPath": "${workspaceFolder}\\.venv39\\Scripts\\python.exe",
-  "python.pythonPath": "${workspaceFolder}\\.venv39\\Scripts\\python.exe",
-  "python.terminal.activateEnvironment": true,
-  "http.proxy": "http://127.0.0.1:7897",
-  "terminal.integrated.env.windows": {
-    "HTTP_PROXY": "http://127.0.0.1:7897",
-    "HTTPS_PROXY": "http://127.0.0.1:7897",
-    "ALL_PROXY": "socks5://127.0.0.1:7897"
-  }
-}
     // Ignore markdownlint rule MD060 (table column style) workspace-wide
     "markdownlint.config": {
         "MD060": false

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,14 @@
 {
+  "python.defaultInterpreterPath": "${workspaceFolder}\\.venv39\\Scripts\\python.exe",
+  "python.pythonPath": "${workspaceFolder}\\.venv39\\Scripts\\python.exe",
+  "python.terminal.activateEnvironment": true,
+  "http.proxy": "http://127.0.0.1:7897",
+  "terminal.integrated.env.windows": {
+    "HTTP_PROXY": "http://127.0.0.1:7897",
+    "HTTPS_PROXY": "http://127.0.0.1:7897",
+    "ALL_PROXY": "socks5://127.0.0.1:7897"
+  }
+}
     // Ignore markdownlint rule MD060 (table column style) workspace-wide
     "markdownlint.config": {
         "MD060": false

--- a/docs/06_程序概览.md
+++ b/docs/06_程序概览.md
@@ -193,12 +193,54 @@ See-you-more-than-her/
 
 ### 2.3 工具链（`tools/aurora/`）
 
-| 文件 | 说明 |
+| 文件 | 端口 | 说明 |
+| --- | --- | --- |
+| `aurora_capture.py` | 5000 | 基础拍照工具，采集 1280×720 灰度图 |
+| `aurora_companion.py` | 5801 | 增强伴侣工具；双 Tab UI = 摄像头采集 + 底盘调试；PC 端 ONNX 推理可选 |
+| `a1_viewer.py` | 5802 | **A1 结果显示工具**（见下方说明） |
+| `chassis_comm.py` | — | Flask Blueprint `/api/chassis/*`；实现 WHEELTEC C50X 11/24 字节协议 |
+| `launch.ps1` | — | 一键启动 aurora_companion，自动打开浏览器 |
+| `launch_a1_viewer.ps1` | — | 一键启动 a1_viewer，自动打开浏览器 |
+| `templates/companion_ui.html` | — | aurora_companion 前端模板 |
+| `templates/a1_viewer.html` | — | a1_viewer 平板友好前端模板 |
+
+#### A1 Viewer（`a1_viewer.py`）
+
+A1 开发板通过 USB-UVC 回传视频，**板端 M1 NPU 已完成 YOLOv8 推理**，硬件 OSD 将检测框直接烧录在帧中。`a1_viewer.py` 不做任何本地推理，只负责：
+
+1. 用**专用抓帧线程**（DirectShow 同线程安全）接收 UVC 帧
+2. 以 MJPEG 流转发到浏览器
+3. 提供平板友好的全屏显示界面
+
+前端预留了以下扩展接口，可在 `a1_viewer.py` 中实现对应路由并挂接：
+
+| API | 用途 |
 | --- | --- |
-| `aurora_capture.py` | 基础拍照工具，Port 5000，采集 1280×720 灰度图（旋转兜底已移除） |
-| `aurora_companion.py` | 增强伴侣工具，Port 5001；双 Tab UI = 摄像头采集 + 底盘调试 |
-| `chassis_comm.py` | Flask Blueprint `/api/chassis/*`；实现 WHEELTEC C50X 11/24 字节协议 |
-| `templates/companion_ui.html` | Jinja2 前端模板；底盘调试 Tab 含接线参考、运动控制、遥测显示 |
+| `/api/pointcloud` | 3D 点云数据（Three.js 渲染） |
+| `/api/telemetry` | 底盘遥测（速度、IMU、电量） |
+| `/stream` | MJPEG 视频流 |
+| `/reconnect` (POST) | 重连摄像头 |
+
+启动方式：
+```powershell
+# 启动 A1 Viewer
+cd tools/aurora
+.\launch_a1_viewer.ps1           # 自动打开浏览器
+.\launch_a1_viewer.ps1 --Device 1 --Port 5803  # 手动指定设备和端口
+```
+
+#### 专用抓帧线程架构（两个工具共用）
+
+Windows DirectShow 要求 `cap.read()` 必须在创建 `VideoCapture` 的同一 OS 线程中调用。两个工具均采用以下架构：
+
+```
+main() ──────────────────────────────→ Flask app.run(threaded=True)
+                                            │
+                                    worker threads (MJPEG)
+                                            │ 只读 _latest_frame
+_capture_thread (专用线程) ───────────→ cap.read() 在此线程内
+    ↑ 在本线程内调用 _try_open()              写入 _latest_frame
+```
 
 aurora_companion.py 底盘调试功能：
 

--- a/tools/aurora/a1_viewer.py
+++ b/tools/aurora/a1_viewer.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""
+A1 Viewer — A1 开发板实时结果显示工具
+
+用途：
+  接收 A1 开发板经 USB-UVC 上传的视频流，板端已在 NPU 完成 YOLOv8 推理
+  并通过硬件 OSD 将检测框烧录在帧中——本工具不再做任何推理，仅负责
+  流转发与显示。
+
+  前端基于 MJPEG + WebSocket，为平板/触摸设备优化，
+  预留了 3D 点云、雷达、遥测等扩展面板的接口。
+
+用法:
+    python a1_viewer.py [--device 0] [--port 5802] [--host 0.0.0.0]
+"""
+
+import argparse
+import contextlib
+import os
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import Optional
+
+import cv2
+import numpy as np
+from flask import Flask, Response, jsonify, render_template
+
+# ─── 摄像头参数 ───────────────────────────────────────────────────────────────
+CAMERA_WIDTH  = 1280
+CAMERA_HEIGHT = 720
+PREFERRED_DEVICE_FILE = Path(__file__).with_name(".a1_camera_device")
+
+app = Flask(__name__, template_folder="templates")
+
+# ─── 全局状态 ─────────────────────────────────────────────────────────────────
+camera: Optional[cv2.VideoCapture] = None
+camera_lock = threading.Lock()
+device_id_global: int = 0
+camera_connected: bool = False
+
+_latest_frame: Optional[np.ndarray] = None
+_frame_lock = threading.Lock()
+_capture_running: bool = False
+_capture_thread: Optional[threading.Thread] = None
+
+_fps_count  = 0
+_fps_ts     = time.time()
+current_fps = 0.0
+
+
+# ─── 工具函数 ─────────────────────────────────────────────────────────────────
+
+@contextlib.contextmanager
+def _suppress_c_stderr():
+    if sys.platform != "win32":
+        yield
+        return
+    try:
+        devnull_fd = os.open(os.devnull, os.O_WRONLY)
+        saved = os.dup(2)
+        os.dup2(devnull_fd, 2)
+        try:
+            yield
+        finally:
+            os.dup2(saved, 2)
+            os.close(saved)
+            os.close(devnull_fd)
+    except Exception:
+        yield
+
+
+def _open_camera(device_id: int) -> Optional[cv2.VideoCapture]:
+    with _suppress_c_stderr():
+        cap = cv2.VideoCapture(
+            device_id,
+            cv2.CAP_DSHOW if sys.platform == "win32" else cv2.CAP_V4L2,
+        )
+        if not cap.isOpened():
+            cap = cv2.VideoCapture(device_id)
+    if not cap.isOpened():
+        return None
+    cap.set(cv2.CAP_PROP_FRAME_WIDTH,  CAMERA_WIDTH)
+    cap.set(cv2.CAP_PROP_FRAME_HEIGHT, CAMERA_HEIGHT)
+    w = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+    h = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+    print(f"[INFO] A1 摄像头已连接: {w}×{h} (设备 {device_id})")
+    return cap
+
+
+# ─── 专用抓帧线程 ─────────────────────────────────────────────────────────────
+# DirectShow 要求 cap.read() 必须在创建 VideoCapture 的同一 OS 线程中调用。
+# 本线程是唯一调用 cap.read() 的地方。Flask MJPEG generator 只读 _latest_frame。
+
+def _capture_thread_func(device_id: int) -> None:
+    global _latest_frame, camera, camera_connected, current_fps, _fps_count, _fps_ts
+    cap = _open_camera(device_id)
+    with camera_lock:
+        camera = cap
+    if cap is None:
+        camera_connected = False
+        print(f"[ERROR] 无法打开摄像头设备 {device_id}")
+        return
+    camera_connected = True
+    while _capture_running:
+        ret, frame = cap.read()
+        if ret and frame is not None:
+            fh, fw = frame.shape[:2]
+            if fh > fw:
+                frame = cv2.rotate(frame, cv2.ROTATE_90_CLOCKWISE)
+            with _frame_lock:
+                _latest_frame = frame
+            camera_connected = True
+            # FPS 计算
+            _fps_count += 1
+            now = time.time()
+            if now - _fps_ts >= 1.0:
+                current_fps = _fps_count / (now - _fps_ts)
+                _fps_count  = 0
+                _fps_ts     = now
+        else:
+            camera_connected = False
+            time.sleep(0.05)
+    cap.release()
+    with camera_lock:
+        camera = None
+
+
+def _start_capture_thread(device_id: int) -> None:
+    global _capture_running, _capture_thread, _latest_frame
+    _stop_capture_thread()
+    _latest_frame    = None
+    _capture_running = True
+    _capture_thread  = threading.Thread(
+        target=_capture_thread_func,
+        args=(device_id,),
+        daemon=True,
+        name=f"A1CaptureThread-{device_id}",
+    )
+    _capture_thread.start()
+
+
+def _stop_capture_thread() -> None:
+    global _capture_running, _capture_thread
+    _capture_running = False
+    if _capture_thread and _capture_thread.is_alive():
+        _capture_thread.join(timeout=2.0)
+    _capture_thread = None
+
+
+# ─── MJPEG 生成器 ─────────────────────────────────────────────────────────────
+
+def _generate_stream():
+    """原样转发 A1 帧（OSD 已由板端硬件烧录），不做任何推理。"""
+    while True:
+        with _frame_lock:
+            raw = _latest_frame.copy() if _latest_frame is not None else None
+
+        if raw is None:
+            blk = np.zeros((CAMERA_HEIGHT, CAMERA_WIDTH, 3), dtype=np.uint8)
+            cv2.putText(blk, "Waiting for A1 board...",
+                        (CAMERA_WIDTH // 2 - 190, CAMERA_HEIGHT // 2 - 10),
+                        cv2.FONT_HERSHEY_SIMPLEX, 1.1, (60, 140, 200), 2)
+            cv2.putText(blk, "Connect A1 via USB and press Reconnect",
+                        (CAMERA_WIDTH // 2 - 250, CAMERA_HEIGHT // 2 + 40),
+                        cv2.FONT_HERSHEY_SIMPLEX, 0.65, (60, 60, 80), 1)
+            _, buf = cv2.imencode(".jpg", blk, [cv2.IMWRITE_JPEG_QUALITY, 50])
+            yield (b"--frame\r\nContent-Type: image/jpeg\r\n\r\n"
+                   + buf.tobytes() + b"\r\n")
+            time.sleep(0.2)
+            continue
+
+        # BGR → 确保三通道（A1 输出已是彩色）
+        frame = raw if len(raw.shape) == 3 else cv2.cvtColor(raw, cv2.COLOR_GRAY2BGR)
+        _, buf = cv2.imencode(".jpg", frame, [cv2.IMWRITE_JPEG_QUALITY, 85])
+        yield (b"--frame\r\nContent-Type: image/jpeg\r\n\r\n"
+               + buf.tobytes() + b"\r\n")
+
+
+# ─── Flask 路由 ───────────────────────────────────────────────────────────────
+
+@app.route("/")
+def index():
+    return render_template("a1_viewer.html")
+
+
+@app.route("/stream")
+def stream():
+    return Response(
+        _generate_stream(),
+        mimetype="multipart/x-mixed-replace; boundary=frame",
+    )
+
+
+@app.route("/status")
+def status():
+    return jsonify({
+        "connected":  camera_connected,
+        "fps":        round(current_fps, 1),
+        "device":     device_id_global,
+        "resolution": f"{CAMERA_WIDTH}x{CAMERA_HEIGHT}",
+    })
+
+
+@app.route("/reconnect", methods=["POST"])
+def reconnect():
+    """停止并重新启动抓帧线程（在线程内重新打开摄像头）。"""
+    _stop_capture_thread()
+    time.sleep(0.3)
+    _start_capture_thread(device_id_global)
+    time.sleep(1.5)
+    return jsonify({"success": camera_connected, "connected": camera_connected})
+
+
+# ─── 数据推送扩展占位 ─────────────────────────────────────────────────────────
+# 未来可在此添加 WebSocket / SSE 端点，用于：
+#   - 3D 点云数据（LiDAR 或深度传感器）
+#   - 底盘遥测（速度、里程、IMU）
+#   - 检测结果 JSON（若需要前端二次处理）
+
+@app.route("/api/pointcloud")
+def api_pointcloud():
+    """点云数据接口（占位）。实现时替换本函数返回实际数据。"""
+    return jsonify({
+        "status": "placeholder",
+        "message": "Point cloud API not yet connected. Implement this endpoint to push LiDAR/depth data.",
+        "format":  "expected: {points: [[x,y,z,intensity], ...], timestamp: float}",
+    })
+
+
+@app.route("/api/telemetry")
+def api_telemetry():
+    """底盘遥测接口（占位）。"""
+    return jsonify({
+        "status": "placeholder",
+        "message": "Telemetry API not yet connected.",
+        "format":  "expected: {vx, vy, omega, battery_pct, timestamp}",
+    })
+
+
+# ─── 入口 ─────────────────────────────────────────────────────────────────────
+
+def main():
+    global device_id_global
+
+    parser = argparse.ArgumentParser(
+        description="A1 Viewer — 接收 A1 开发板 YOLOv8+OSD 视频流并在浏览器显示"
+    )
+    parser.add_argument("--device", type=int, default=-1,
+                        help="摄像头设备 ID (默认: -1 自动选择)")
+    parser.add_argument("--port",   type=int, default=5802,
+                        help="Web 服务端口 (默认: 5802)")
+    parser.add_argument("--host",   type=str, default="0.0.0.0",
+                        help="监听地址")
+    args = parser.parse_args()
+
+    # 自动选设备
+    if args.device >= 0:
+        device_id_global = args.device
+    else:
+        try:
+            device_id_global = int(
+                PREFERRED_DEVICE_FILE.read_text(encoding="utf-8").strip()
+            )
+        except Exception:
+            device_id_global = 0
+
+    print(f"[INFO] A1 Viewer 启动，设备 {device_id_global}，端口 {args.port}")
+    _start_capture_thread(device_id_global)
+    time.sleep(1.0)
+    if not camera_connected:
+        print("[WARN] 摄像头未就绪，请连接 A1 后点击页面中的 Reconnect")
+    print(f"[INFO] 打开浏览器访问: http://localhost:{args.port}")
+    app.run(host=args.host, port=args.port, debug=False, threaded=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/aurora/aurora_companion.py
+++ b/tools/aurora/aurora_companion.py
@@ -263,14 +263,24 @@ def _try_open(device_id: int) -> Optional[cv2.VideoCapture]:
     if not cap.isOpened():
         return None
 
+    # 仅在摄像头支持时才强制灰度 FOURCC，否则保持驱动默认值
+    # 若不支持（如 NoY8 设备），不要强设 FOURCC 以免 DirectShow 管线崩溃
+    # 部分驱动在 cap 已开启后调用 set(FOURCC) 会抛 C++ 异常，需捕获
     for s in ("Y800", "GREY", "Y8  "):
-        cap.set(cv2.CAP_PROP_FOURCC, cv2.VideoWriter_fourcc(*s))
+        try:
+            fourcc = cv2.VideoWriter_fourcc(*s)
+            cap.set(cv2.CAP_PROP_FOURCC, fourcc)
+            if int(cap.get(cv2.CAP_PROP_FOURCC)) == fourcc:
+                break   # 成功接受则停止，避免用无效 FOURCC 破坏流
+        except Exception:
+            break       # 驱动抛异常说明不支持 FOURCC 切换，直接跳过
+    # 注意：不设置 CAP_PROP_CONVERT_RGB=0，让 OpenCV / DirectShow 正常解码
+    # 设置 0 会禁用 BGR 转换，在不支持 Y8 的设备上导致管线几帧后崩溃
 
     cap.set(cv2.CAP_PROP_FRAME_WIDTH,  CAMERA_WIDTH)
     cap.set(cv2.CAP_PROP_FRAME_HEIGHT, CAMERA_HEIGHT)
     cap.set(cv2.CAP_PROP_FPS,          CAMERA_FPS)
-    cap.set(cv2.CAP_PROP_CONVERT_RGB,  0)
-    cap.set(cv2.CAP_PROP_BUFFERSIZE,   1)   # 减少缓冲，降低切换后首帧延迟
+    cap.set(cv2.CAP_PROP_BUFFERSIZE,   2)   # 給驱动留 2 帧缓冲，避免 1 帧时掉帧
 
     w = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
     h = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
@@ -528,10 +538,10 @@ def generate_frames():
                     global camera, camera_connected, _reconnect_in_progress
                     new_cap = _try_open(device_id_global)
                     with camera_lock:
-                        old = camera
-                        camera = new_cap
-                    if old:
-                        old.release()
+                        old = camera   # noqa: F841 — 延迟 GC 回收，避免在 generate_frames
+                        camera = new_cap  # 仍持有 old 引用时就调用 old.release() 造成崩溃
+                    # 不立即 old.release()：generate_frames 可能当前迭代仍在 cap.read(old) 中
+                    # Python GC 会在所有引用消失后自动调用 VideoCapture.__del__ -> release()
                     if new_cap:
                         print("[INFO] 摄像头自动重连成功")
                         camera_connected = True

--- a/tools/aurora/aurora_companion.py
+++ b/tools/aurora/aurora_companion.py
@@ -73,6 +73,18 @@ current_fps = 0.0
 camera_connected = False
 _fail_streak = 0
 _orientation_warned = False
+
+# ─── 专用抓帧状态（capture thread → MJPEG generator）───────────────────────────
+_latest_frame: Optional[np.ndarray] = None   # 抓帧线程写入，generator 只读
+_frame_lock = threading.Lock()
+_capture_running = False
+_capture_thread: Optional[threading.Thread] = None
+
+# ─── 专用抓帧状态（capture thread → MJPEG generator）───────────────────────────
+_latest_frame: Optional[np.ndarray] = None   # 抓帧线程写入，generator 只读
+_frame_lock = threading.Lock()
+_capture_running = False
+_capture_thread: Optional[threading.Thread] = None
 MAX_DEVICE_SCAN = 5
 PREFERRED_DEVICE_FILE = Path(__file__).with_name(".a1_camera_device")
 
@@ -256,23 +268,123 @@ def choose_camera_device(requested_device: int) -> Tuple[int, list]:
     candidates_sorted = sorted(candidates, key=lambda x: (x["score"], x["id"]), reverse=True)
     return candidates_sorted[0]["id"], candidates_sorted
 
-
-def _try_open(device_id: int) -> Optional[cv2.VideoCapture]:
-    cap = _open_raw_camera(device_id)
-    if not cap.isOpened():
-        return None
-
-    # 不强设 FOURCC：对 Color/NoY8 设备设置 Y800 会无声损坏 DirectShow 管线
-    # _read_gray 会在读帧后统一做 BGR→GRAY 转换
+只设分辨率，不强设 FOURCC / FPS / BUFFERSIZE
+    # 部分驱动对这些额外属性处理有 bug，宁可使用驱动默认值
     cap.set(cv2.CAP_PROP_FRAME_WIDTH,  CAMERA_WIDTH)
     cap.set(cv2.CAP_PROP_FRAME_HEIGHT, CAMERA_HEIGHT)
-    cap.set(cv2.CAP_PROP_FPS,          CAMERA_FPS)
-    cap.set(cv2.CAP_PROP_BUFFERSIZE,   2)
 
     w = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
     h = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
     print(f"[INFO] 摄像头已连接: {w}×{h} (设备 {device_id})")
     return cap
+
+
+# ─── 专用抓帧线程 ─────────────────────────────────────────────────────────────
+
+def _capture_thread_func() -> None:
+    """后台专用线程：持续在同一线程内调用 cap.read()，绕开 DirectShow
+    要求 cap.read() 必须在创建 VideoCapture 的线程中调用的限制。
+    Flask MJPEG generator 只读 _latest_frame，永远不直接调用 cap.read()。
+    """
+    global _latest_frame, camera_connected, _fail_streak
+    consec_fail = 0
+    while _capture_running:
+        with camera_lock:
+            cap = camera
+        if cap is None:
+            camera_connected = False
+            time.sleep(0.05)
+            continue
+        ret, frame = cap.read()
+        if ret and frame is not None:
+            # 竖屏纠正
+            fh, fw = frame.shape[:2]
+            if fh > fw:
+                frame = cv2.rotate(frame, cv2.ROTATE_90_CLOCKWISE)
+            with _frame_lock:
+                _latest_frame = frame      # 原始帧（BGR 或 GRAY，图像原样存储）
+            camera_connected = True
+            consec_fail = 0
+            _fail_streak = 0
+        else:
+            consec_fail += 1
+            _fail_streak = consec_fail
+            if consec_fail >= 5:
+                camera_connected = False
+            time.sleep(0.03)
+
+
+def _start_capture_thread() -> None:
+    global _capture_running, _capture_thread, _latest_frame
+    _stop_capture_thread()
+    _latest_frame = None
+    _capture_running = True
+    _capture_thread = threading.Thread(target=_capture_thread_func, daemon=True, name="CaptureThread")
+    _capture_thread.start()
+
+
+def _stop_capture_thread() -> None:
+    global _capture_running, _capture_thread
+    _capture_running = False
+    if _capture_thread and _capture_thread.is_alive():
+        _capture_thread.join(timeout=1.0)
+    _capture_thread = None
+    w = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+    h = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+    print(f"[INFO] 摄像头已连接: {w}×{h} (设备 {device_id})")
+    return cap
+
+
+# ─── 专用抓帧线程 ─────────────────────────────────────────────────────────────
+
+def _capture_thread_func() -> None:
+    """后台专用线程：持续在同一线程内调用 cap.read()，绕开 DirectShow
+    要求 cap.read() 必须在创建 VideoCapture 的线程中调用的限制。
+    Flask MJPEG generator 只读 _latest_frame，永远不直接调用 cap.read()。
+    """
+    global _latest_frame, camera_connected, _fail_streak
+    consec_fail = 0
+    while _capture_running:
+        with camera_lock:
+            cap = camera
+        if cap is None:
+            camera_connected = False
+            time.sleep(0.05)
+            continue
+        ret, frame = cap.read()
+        if ret and frame is not None:
+            # 竖屏纠正
+            fh, fw = frame.shape[:2]
+            if fh > fw:
+                frame = cv2.rotate(frame, cv2.ROTATE_90_CLOCKWISE)
+            with _frame_lock:
+                _latest_frame = frame      # 原始帧（BGR 或 GRAY，图像原样存储）
+            camera_connected = True
+            consec_fail = 0
+            _fail_streak = 0
+        else:
+            consec_fail += 1
+            _fail_streak = consec_fail
+            if consec_fail >= 5:
+                camera_connected = False
+            time.sleep(0.03)
+
+
+def _start_capture_thread() -> None:
+    global _capture_running, _capture_thread, _latest_frame
+    _stop_capture_thread()
+    _latest_frame = None
+    _capture_running = True
+    _capture_thread = threading.Thread(target=_capture_thread_func, daemon=True, name="CaptureThread")
+    _capture_thread.start()
+
+
+def _stop_capture_thread() -> None:
+    global _capture_running, _capture_thread
+    _capture_running = False
+    if _capture_thread and _capture_thread.is_alive():
+        _capture_thread.join(timeout=1.0)
+    _capture_thread = None
 
 
 def _read_gray(cap: cv2.VideoCapture) -> Optional[np.ndarray]:
@@ -439,74 +551,15 @@ def detect_on_frame(frame_gray: np.ndarray):
     output_names = [o.name for o in sess.get_outputs()]
     outputs = sess.run(output_names, {sess.get_inputs()[0].name: inp})
 
-    # head6 输出顺序：cv3.0 cv3.1 cv3.2 cv2.0 cv2.1 cv2.2
-    cls_outs = outputs[:3]
-    reg_outs = outputs[3:]
-    detections = _decode_yolov8(cls_outs, reg_outs)
-
-    results = []
-    for box, score, cls_id in detections:
-        x1 = max(0.0, (box[0] - pad_x) / scale)
-        y1 = max(0.0, (box[1] - pad_y) / scale)
-        x2 = min(float(w), (box[2] - pad_x) / scale)
-        y2 = min(float(h), (box[3] - pad_y) / scale)
-        results.append((x1, y1, x2, y2, score, cls_id))
-    return results
-
-
-def _save_capture(frame: np.ndarray, fmt: str) -> dict:
-    global capture_count
-    tw, th = CAPTURE_FORMATS[fmt]
-
-    if fmt == "640x360":
-        # 传感器 1280×720 → 中心裁剪 640×360
-        out = crop_center(frame, tw, th)
-    else:
-        out = frame.copy()
-
-    # 确保尺寸正确
-    if out.shape[1] != tw or out.shape[0] != th:
-        out = cv2.resize(out, (tw, th))
-
-    capture_count += 1
-    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
-    name = f"capture_{ts}_{capture_count:04d}_{fmt}.png"
-    path = os.path.join(output_dir, name)
-    cv2.imwrite(path, out)
-
-    thumb = cv2.resize(out, (160, 90 if fmt == "640x360" else 80))
-    _, buf = cv2.imencode(".jpg", thumb, [cv2.IMWRITE_JPEG_QUALITY, 72])
-    thumb_b64 = base64.b64encode(buf).decode()
-
-    info = {
-        "filename": name,
-        "format": fmt,
-        "size": f"{tw}×{th}",
-        "thumb": thumb_b64,
-        "time": datetime.now().strftime("%H:%M:%S"),
-        "index": capture_count,
-    }
-    recent_captures.appendleft(info)
-    print(f"[CAPTURE] {path}  ({tw}×{th})")
-    return info
-
-
-# ─── 视频流 ───────────────────────────────────────────────────────────────────
-
-
-def generate_frames():
-    global current_fps, _frame_count, _fps_ts, camera_connected, _fail_streak
+    """MJPEG 预览流。只读 _latest_frame（由 _capture_thread_func 写入），
+    绝不自己调用 cap.read()，避免 DirectShow 跨线程崩溃。"""
+    global current_fps, _frame_count, _fps_ts, camera_connected
 
     while True:
-        with camera_lock:
-            cap = camera
+        with _frame_lock:
+            raw = _latest_frame.copy() if _latest_frame is not None else None
 
-        frame = _read_gray(cap) if cap else None
-
-        if frame is None:
-            camera_connected = False
-            _fail_streak += 1
-            # 不自动重连，保持稳定，等待用户点击「刷新摄像头」
+        if raw is None:
             blk = np.zeros((CAMERA_HEIGHT, CAMERA_WIDTH, 3), dtype=np.uint8)
             cv2.putText(blk, "No Signal",
                         (CAMERA_WIDTH // 2 - 90, CAMERA_HEIGHT // 2 - 10),
@@ -517,13 +570,10 @@ def generate_frames():
             _, buf = cv2.imencode(".jpg", blk, [cv2.IMWRITE_JPEG_QUALITY, 50])
             yield (b"--frame\r\nContent-Type: image/jpeg\r\n\r\n"
                    + buf.tobytes() + b"\r\n")
-            time.sleep(0.5)
+            time.sleep(0.1)
             continue
 
         camera_connected = True
-        _fail_streak = 0
-
-        # FPS 计算
         _frame_count += 1
         now = time.time()
         if now - _fps_ts >= 1.0:
@@ -531,18 +581,69 @@ def generate_frames():
             _frame_count = 0
             _fps_ts = now
 
-        # 绘制叠加层
-        disp = cv2.cvtColor(frame, cv2.COLOR_GRAY2BGR)
+        # 确保 BGR 三通道（原样输出，不强制灰度）
+        if len(raw.shape) == 2:
+            disp = cv2.cvtColor(raw, cv2.COLOR_GRAY2BGR)
+        else:
+            disp = raw.copy()
+
         h, w = disp.shape[:2]
         cx, cy = w // 2, h // 2
+        x1, y1, x2, y2 = cx - 320, cy - 180, cx + 320, cy + 180
+        cv2.rectangle(disp, (x1, y1), (x2, y2), (45, 210, 100), 1)
+        cv2.putText(disp, "640x360 train", (x1 + 6, y1 + 20),
+                    cv2.FONT_HERSHEY_SIMPLEX, 0.52, (45, 210, 100), 1)res.appendleft(info)
+    print(f"[CAPTURE] {path}  ({tw}×{th})")
+    return info
 
-        # 640×360 训练裁剪框
+
+# ─── 视频流 ───────────────────────────────────────────────────────────────────
+
+
+def generate_frames():
+    """MJPEG 预览流。只读 _latest_frame（由 _capture_thread_func 写入），
+    绝不自己调用 cap.read()，避免 Direct只读 _latest_frame，不直接调用 cap.read()。"""
+    while True:
+        with _frame_lock:
+            raw = _latest_frame.copy() if _latest_frame is not None else None
+
+        if raw is None:
+            blk = np.zeros((CAMERA_HEIGHT, CAMERA_WIDTH, 3), dtype=np.uint8)
+            cv2.putText(blk, "No Signal", (CAMERA_WIDTH // 2 - 80, CAMERA_HEIGHT // 2),
+                        cv2.FONT_HERSHEY_SIMPLEX, 1.0, (60, 60, 60), 2)
+            _, buf = cv2.imencode(".jpg", blk, [cv2.IMWRITE_JPEG_QUALITY, 50])
+            yield (b"--frame\r\nContent-Type: image/jpeg\r\n\r\n" + buf.tobytes() + b"\r\n")
+            time.sleep(0.5)
+            continue
+
+        # YOLOv8 需要灰度输入
+        frame_gray = raw if len(raw.shape) == 2 else cv2.cvtColor(raw, cv2.COLOR_BGR2GRAY)
+        detections = detect_on_frame(frame_gray)
+        display = raw.copy() if len(raw.shape) == 3 else cv2.cvtColor(rawent-Type: image/jpeg\r\n\r\n"
+                   + buf.tobytes() + b"\r\n")
+            time.sleep(0.1)
+            continue
+
+        camera_connected = True
+        _frame_count += 1
+        now = time.time()
+        if now - _fps_ts >= 1.0:
+            current_fps = _frame_count / (now - _fps_ts)
+            _frame_count = 0
+            _fps_ts = now
+
+        # 确保 BGR 三通道（原样输出，不强制灰度）
+        if len(raw.shape) == 2:
+            disp = cv2.cvtColor(raw, cv2.COLOR_GRAY2BGR)
+        else:
+            disp = raw.copy()
+
+        h, w = disp.shape[:2]
+        cx, cy = w // 2, h // 2
         x1, y1, x2, y2 = cx - 320, cy - 180, cx + 320, cy + 180
         cv2.rectangle(disp, (x1, y1), (x2, y2), (45, 210, 100), 1)
         cv2.putText(disp, "640x360 train", (x1 + 6, y1 + 20),
                     cv2.FONT_HERSHEY_SIMPLEX, 0.52, (45, 210, 100), 1)
-
-        # FPS 水印
         cv2.putText(disp, f"FPS {current_fps:.1f}", (w - 100, 24),
                     cv2.FONT_HERSHEY_SIMPLEX, 0.6, (180, 180, 180), 1)
 
@@ -552,13 +653,12 @@ def generate_frames():
 
 
 def _generate_detect_frames():
-    """YOLOv8+OSD 检测视频流（MJPEG）。"""
+    """YOLOv8+OSD 检测视频流（MJPEG）。只读 _latest_frame，不直接调用 cap.read()。"""
     while True:
-        with camera_lock:
-            cap = camera
-        frame = _read_gray(cap) if cap else None
+        with _frame_lock:
+            raw = _latest_frame.copy() if _latest_frame is not None else None
 
-        if frame is None:
+        if raw is None:
             blk = np.zeros((CAMERA_HEIGHT, CAMERA_WIDTH, 3), dtype=np.uint8)
             cv2.putText(blk, "No Signal", (CAMERA_WIDTH // 2 - 80, CAMERA_HEIGHT // 2),
                         cv2.FONT_HERSHEY_SIMPLEX, 1.0, (60, 60, 60), 2)
@@ -567,8 +667,10 @@ def _generate_detect_frames():
             time.sleep(0.5)
             continue
 
-        detections = detect_on_frame(frame)
-        display = cv2.cvtColor(frame, cv2.COLOR_GRAY2BGR)
+        # YOLOv8 需要灰度输入
+        frame_gray = raw if len(raw.shape) == 2 else cv2.cvtColor(raw, cv2.COLOR_BGR2GRAY)
+        detections = detect_on_frame(frame_gray)
+        display = raw.copy() if len(raw.shape) == 3 else cv2.cvtColor(raw, cv2.COLOR_GRAY2BGR)
 
         for (x1, y1, x2, y2, score, cls_id) in detections:
             color = _CLASS_COLORS[cls_id % len(_CLASS_COLORS)]
@@ -577,11 +679,12 @@ def _generate_detect_frames():
             label = f"{name} {score:.2f}"
             (tw, th), _ = cv2.getTextSize(label, cv2.FONT_HERSHEY_SIMPLEX, 0.5, 1)
             ty = max(int(y1) - 4, th + 4)
-            cv2.rectangle(display, (int(x1), ty - th - 4), (int(x1) + tw + 4, ty), color, -1)
-            cv2.putText(display, label, (int(x1) + 2, ty - 2),
-                        cv2.FONT_HERSHEY_SIMPLEX, 0.5, (0, 0, 0), 1)
-
-        n = len(detections)
+         _frame_lock:
+        raw = _latest_frame.copy() if _latest_frame is not None else None
+    if raw is None:
+        return jsonify({"success": False, "error": "无法获取摄像头画面"})
+    # 统一转灰度保存（训练数据集格式）
+    frame = raw if len(raw.shape) == 2 else cv2.cvtColor(raw, cv2.COLOR_BGR2GRAY
         cv2.putText(display, f"Det: {n}  conf>={_DETECT_CONF:.2f}", (8, 28),
                     cv2.FONT_HERSHEY_SIMPLEX, 0.7, (0, 200, 80), 2)
 
@@ -589,17 +692,17 @@ def _generate_detect_frames():
         yield (b"--frame\r\nContent-Type: image/jpeg\r\n\r\n" + buf.tobytes() + b"\r\n")
 
 
-# ─── Flask 路由 ───────────────────────────────────────────────────────────────
-
-@app.route("/")
-def index():
-    return render_template("companion_ui.html", output_dir=output_dir)
-
-
-@app.route("/video_feed")
-def video_feed():
-    return Response(generate_frames(),
-                    mimetype="multipart/x-mixed-replace; boundary=frame")
+# ─── 先停抓帧线程（它持有 cap 引用），再换摄像头，再重启
+    _stop_capture_thread()
+    new_cam = _try_open(device_id_global)
+    ok = new_cam is not None
+    with camera_lock:
+        _old_cam = camera  # noqa: F841 — GC 负责释放，避免并发 release
+        camera = new_cam if ok else None
+    _fail_streak = 0
+    if ok:
+        camera_connected = True
+        _start_capture_thread()ultipart/x-mixed-replace; boundary=frame")
 
 
 @app.route("/detect_feed")
@@ -628,11 +731,12 @@ def do_capture():
     fmt = data.get("format", "1280x720")
     if fmt not in CAPTURE_FORMATS:
         return jsonify({"success": False, "error": f"不支持的格式: {fmt}"})
-    with camera_lock:
-        cap = camera
-    frame = _read_gray(cap) if cap else None
-    if frame is None:
+    with _frame_lock:
+        raw = _latest_frame.copy() if _latest_frame is not None else None
+    if raw is None:
         return jsonify({"success": False, "error": "无法获取摄像头画面"})
+    # 统一转灰度保存（训练数据集格式）
+    frame = raw if len(raw.shape) == 2 else cv2.cvtColor(raw, cv2.COLOR_BGR2GRAY)
     info = _save_capture(frame, fmt)
     return jsonify({"success": True, **info})
 
@@ -640,18 +744,18 @@ def do_capture():
 @app.route("/refresh_camera", methods=["POST"])
 def refresh_camera():
     global camera, _fail_streak, camera_connected
-    # 在锁外打开新摄像头，避免阻塞视频流生成器
+    # 先停抓帧线程（它持有 cap 引用），再换摄像头，再重启
+    _stop_capture_thread()
     new_cam = _try_open(device_id_global)
     ok = new_cam is not None
+    _stop_capture_thread()
     with camera_lock:
-        # 不立即 release 旧摄像头：generate_frames 可能仍在 cap.read() 中
-        # 让 Python GC 在旧引用归零后自动释放
-        _old_cam = camera  # noqa: F841
-        camera = new_cam if ok else None
+        _old_camera = camera  # noqa: F841 — GC 负责释放
+        camera = new_camera
+        device_id_global = new_device
     _fail_streak = 0
-    if ok:
-        camera_connected = True
-        print("[INFO] 摄像头手动刷新成功")
+    camera_connected = True
+    _start_capture_thread()刷新成功")
         return jsonify({"success": True, "message": "摄像头已重新连接"})
     camera_connected = False
     print("[WARN] 摄像头刷新失败")
@@ -696,14 +800,14 @@ def switch_camera():
     if new_camera is None:
         return jsonify({"success": False, "error": "目标摄像头无法打开"})
 
+    _stop_capture_thread()
     with camera_lock:
-        # 不立即 release 旧摄像头，防止 generate_frames 仍在使用时并发崩溃
-        _old_camera = camera  # noqa: F841
+        _old_camera = camera  # noqa: F841 — GC 负责释放
         camera = new_camera
         device_id_global = new_device
-
     _fail_streak = 0
     camera_connected = True
+    _start_capture_thread()
     save_preferred_device(new_device)
     print(f"[INFO] 已切换到摄像头设备 {new_device}")
     return jsonify({"success": True, "device": new_device})
@@ -714,6 +818,7 @@ def recent_captures_api():
     return jsonify(list(recent_captures))
 
 
+        _start_capture_thread()   # 启动专用抓帧线程
 @app.route("/status")
 def status():
     with camera_lock:
@@ -766,6 +871,7 @@ def main():
         print("[WARN] 摄像头未连接，工具仍可启动，请连接后点击「刷新摄像头」")
     else:
         save_preferred_device(selected_device)
+        _start_capture_thread()   # 启动专用抓帧线程
 
     print(f"[INFO] Aurora Companion 已启动: http://localhost:{args.port}")
     print(f"[INFO] 快捷键: 1=1280×720  2=640×360  R=刷新摄像头")

--- a/tools/aurora/aurora_companion.py
+++ b/tools/aurora/aurora_companion.py
@@ -72,7 +72,6 @@ _fps_ts = time.time()
 current_fps = 0.0
 camera_connected = False
 _fail_streak = 0
-_last_reconnect = 0.0
 _orientation_warned = False
 MAX_DEVICE_SCAN = 5
 PREFERRED_DEVICE_FILE = Path(__file__).with_name(".a1_camera_device")
@@ -263,24 +262,12 @@ def _try_open(device_id: int) -> Optional[cv2.VideoCapture]:
     if not cap.isOpened():
         return None
 
-    # 仅在摄像头支持时才强制灰度 FOURCC，否则保持驱动默认值
-    # 若不支持（如 NoY8 设备），不要强设 FOURCC 以免 DirectShow 管线崩溃
-    # 部分驱动在 cap 已开启后调用 set(FOURCC) 会抛 C++ 异常，需捕获
-    for s in ("Y800", "GREY", "Y8  "):
-        try:
-            fourcc = cv2.VideoWriter_fourcc(*s)
-            cap.set(cv2.CAP_PROP_FOURCC, fourcc)
-            if int(cap.get(cv2.CAP_PROP_FOURCC)) == fourcc:
-                break   # 成功接受则停止，避免用无效 FOURCC 破坏流
-        except Exception:
-            break       # 驱动抛异常说明不支持 FOURCC 切换，直接跳过
-    # 注意：不设置 CAP_PROP_CONVERT_RGB=0，让 OpenCV / DirectShow 正常解码
-    # 设置 0 会禁用 BGR 转换，在不支持 Y8 的设备上导致管线几帧后崩溃
-
+    # 不强设 FOURCC：对 Color/NoY8 设备设置 Y800 会无声损坏 DirectShow 管线
+    # _read_gray 会在读帧后统一做 BGR→GRAY 转换
     cap.set(cv2.CAP_PROP_FRAME_WIDTH,  CAMERA_WIDTH)
     cap.set(cv2.CAP_PROP_FRAME_HEIGHT, CAMERA_HEIGHT)
     cap.set(cv2.CAP_PROP_FPS,          CAMERA_FPS)
-    cap.set(cv2.CAP_PROP_BUFFERSIZE,   2)   # 給驱动留 2 帧缓冲，避免 1 帧时掉帧
+    cap.set(cv2.CAP_PROP_BUFFERSIZE,   2)
 
     w = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
     h = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
@@ -506,15 +493,9 @@ def _save_capture(frame: np.ndarray, fmt: str) -> dict:
 
 # ─── 视频流 ───────────────────────────────────────────────────────────────────
 
-_reconnect_in_progress = False  # 防止重入
-
 
 def generate_frames():
-    global camera, current_fps, _frame_count, _fps_ts
-    global camera_connected, _fail_streak, _last_reconnect, _reconnect_in_progress
-
-    FAIL_THRESH      = 10
-    RECONNECT_GAP    = 3.0
+    global current_fps, _frame_count, _fps_ts, camera_connected, _fail_streak
 
     while True:
         with camera_lock:
@@ -525,41 +506,18 @@ def generate_frames():
         if frame is None:
             camera_connected = False
             _fail_streak += 1
-            now = time.time()
-            if (_fail_streak >= FAIL_THRESH
-                    and now - _last_reconnect > RECONNECT_GAP
-                    and not _reconnect_in_progress):
-                _last_reconnect = now
-                _fail_streak = 0
-                _reconnect_in_progress = True
-                print("[INFO] 自动重连摄像头（后台线程）...")
-
-                def _bg_reconnect():
-                    global camera, camera_connected, _reconnect_in_progress
-                    new_cap = _try_open(device_id_global)
-                    with camera_lock:
-                        old = camera   # noqa: F841 — 延迟 GC 回收，避免在 generate_frames
-                        camera = new_cap  # 仍持有 old 引用时就调用 old.release() 造成崩溃
-                    # 不立即 old.release()：generate_frames 可能当前迭代仍在 cap.read(old) 中
-                    # Python GC 会在所有引用消失后自动调用 VideoCapture.__del__ -> release()
-                    if new_cap:
-                        print("[INFO] 摄像头自动重连成功")
-                        camera_connected = True
-                    _reconnect_in_progress = False
-
-                threading.Thread(target=_bg_reconnect, daemon=True).start()
-
-            # 占位黑帧
-            blk = np.zeros((CAMERA_HEIGHT, CAMERA_WIDTH), dtype=np.uint8)
-            msg = "Reconnecting..." if _reconnect_in_progress else "No Signal  —  Reconnecting..."
-            cv2.putText(blk, msg,
-                        (CAMERA_WIDTH // 2 - 200, CAMERA_HEIGHT // 2),
-                        cv2.FONT_HERSHEY_SIMPLEX, 0.9, (60, 60, 60), 2)
-            disp = cv2.cvtColor(blk, cv2.COLOR_GRAY2BGR)
-            _, buf = cv2.imencode(".jpg", disp, [cv2.IMWRITE_JPEG_QUALITY, 50])
+            # 不自动重连，保持稳定，等待用户点击「刷新摄像头」
+            blk = np.zeros((CAMERA_HEIGHT, CAMERA_WIDTH, 3), dtype=np.uint8)
+            cv2.putText(blk, "No Signal",
+                        (CAMERA_WIDTH // 2 - 90, CAMERA_HEIGHT // 2 - 10),
+                        cv2.FONT_HERSHEY_SIMPLEX, 1.2, (80, 80, 80), 2)
+            cv2.putText(blk, "Click [Refresh Camera] to reconnect",
+                        (CAMERA_WIDTH // 2 - 220, CAMERA_HEIGHT // 2 + 36),
+                        cv2.FONT_HERSHEY_SIMPLEX, 0.6, (60, 60, 60), 1)
+            _, buf = cv2.imencode(".jpg", blk, [cv2.IMWRITE_JPEG_QUALITY, 50])
             yield (b"--frame\r\nContent-Type: image/jpeg\r\n\r\n"
                    + buf.tobytes() + b"\r\n")
-            time.sleep(0.1)
+            time.sleep(0.5)
             continue
 
         camera_connected = True
@@ -681,19 +639,21 @@ def do_capture():
 
 @app.route("/refresh_camera", methods=["POST"])
 def refresh_camera():
-    global camera, _fail_streak
+    global camera, _fail_streak, camera_connected
     # 在锁外打开新摄像头，避免阻塞视频流生成器
     new_cam = _try_open(device_id_global)
     ok = new_cam is not None
     with camera_lock:
-        old_cam = camera
+        # 不立即 release 旧摄像头：generate_frames 可能仍在 cap.read() 中
+        # 让 Python GC 在旧引用归零后自动释放
+        _old_cam = camera  # noqa: F841
         camera = new_cam if ok else None
-    if old_cam:
-        old_cam.release()
     _fail_streak = 0
     if ok:
+        camera_connected = True
         print("[INFO] 摄像头手动刷新成功")
         return jsonify({"success": True, "message": "摄像头已重新连接"})
+    camera_connected = False
     print("[WARN] 摄像头刷新失败")
     return jsonify({"success": False, "error": "无法连接到摄像头设备"})
 
@@ -737,11 +697,10 @@ def switch_camera():
         return jsonify({"success": False, "error": "目标摄像头无法打开"})
 
     with camera_lock:
-        old_camera = camera
+        # 不立即 release 旧摄像头，防止 generate_frames 仍在使用时并发崩溃
+        _old_camera = camera  # noqa: F841
         camera = new_camera
         device_id_global = new_device
-    if old_camera:
-        old_camera.release()
 
     _fail_streak = 0
     camera_connected = True

--- a/tools/aurora/aurora_companion.py
+++ b/tools/aurora/aurora_companion.py
@@ -74,17 +74,14 @@ camera_connected = False
 _fail_streak = 0
 _orientation_warned = False
 
-# ─── 专用抓帧状态（capture thread → MJPEG generator）───────────────────────────
-_latest_frame: Optional[np.ndarray] = None   # 抓帧线程写入，generator 只读
+# ─── 专用抓帧线程全局状态 ──────────────────────────────────────────────────────
+# 抓帧线程写入，Flask MJPEG generator 只读。DirectShow 要求 cap.read()
+# 必须在创建 VideoCapture 的同一 OS 线程内调用。
+_latest_frame: Optional[np.ndarray] = None
 _frame_lock = threading.Lock()
 _capture_running = False
 _capture_thread: Optional[threading.Thread] = None
 
-# ─── 专用抓帧状态（capture thread → MJPEG generator）───────────────────────────
-_latest_frame: Optional[np.ndarray] = None   # 抓帧线程写入，generator 只读
-_frame_lock = threading.Lock()
-_capture_running = False
-_capture_thread: Optional[threading.Thread] = None
 MAX_DEVICE_SCAN = 5
 PREFERRED_DEVICE_FILE = Path(__file__).with_name(".a1_camera_device")
 
@@ -268,8 +265,14 @@ def choose_camera_device(requested_device: int) -> Tuple[int, list]:
     candidates_sorted = sorted(candidates, key=lambda x: (x["score"], x["id"]), reverse=True)
     return candidates_sorted[0]["id"], candidates_sorted
 
-只设分辨率，不强设 FOURCC / FPS / BUFFERSIZE
-    # 部分驱动对这些额外属性处理有 bug，宁可使用驱动默认值
+
+def _try_open(device_id: int) -> Optional[cv2.VideoCapture]:
+    cap = _open_raw_camera(device_id)
+    if not cap.isOpened():
+        return None
+
+    # 只设分辨率，不强设 FOURCC / FPS / BUFFERSIZE
+    # 部分 DirectShow 驱动对额外属性设置有 bug，安全起见不设
     cap.set(cv2.CAP_PROP_FRAME_WIDTH,  CAMERA_WIDTH)
     cap.set(cv2.CAP_PROP_FRAME_HEIGHT, CAMERA_HEIGHT)
 
@@ -281,28 +284,32 @@ def choose_camera_device(requested_device: int) -> Tuple[int, list]:
 
 # ─── 专用抓帧线程 ─────────────────────────────────────────────────────────────
 
-def _capture_thread_func() -> None:
-    """后台专用线程：持续在同一线程内调用 cap.read()，绕开 DirectShow
-    要求 cap.read() 必须在创建 VideoCapture 的线程中调用的限制。
-    Flask MJPEG generator 只读 _latest_frame，永远不直接调用 cap.read()。
+def _capture_thread_func(device_id: int) -> None:
+    """DirectShow 安全抓帧线程。
+
+    关键：VideoCapture 的**创建**和所有**读帧**都在同一个 OS 线程内完成。
+    Flask MJPEG generator 运行在另一个 worker 线程，只读 _latest_frame，
+    永远不直接调用 cap.read()。
     """
-    global _latest_frame, camera_connected, _fail_streak
+    global _latest_frame, camera, camera_connected, _fail_streak
+    # 在本线程内创建 VideoCapture（满足 DirectShow 同线程要求）
+    cap = _try_open(device_id)
+    with camera_lock:
+        camera = cap
+    if cap is None:
+        camera_connected = False
+        print(f"[ERROR] 抓帧线程：无法打开设备 {device_id}")
+        return
+    camera_connected = True
     consec_fail = 0
     while _capture_running:
-        with camera_lock:
-            cap = camera
-        if cap is None:
-            camera_connected = False
-            time.sleep(0.05)
-            continue
         ret, frame = cap.read()
         if ret and frame is not None:
-            # 竖屏纠正
             fh, fw = frame.shape[:2]
-            if fh > fw:
+            if fh > fw:   # 竖屏纠正
                 frame = cv2.rotate(frame, cv2.ROTATE_90_CLOCKWISE)
             with _frame_lock:
-                _latest_frame = frame      # 原始帧（BGR 或 GRAY，图像原样存储）
+                _latest_frame = frame   # 存储原始帧（BGR 或 GRAY）
             camera_connected = True
             consec_fail = 0
             _fail_streak = 0
@@ -312,14 +319,22 @@ def _capture_thread_func() -> None:
             if consec_fail >= 5:
                 camera_connected = False
             time.sleep(0.03)
+    cap.release()
+    with camera_lock:
+        camera = None
 
 
-def _start_capture_thread() -> None:
+def _start_capture_thread(device_id: int) -> None:
     global _capture_running, _capture_thread, _latest_frame
     _stop_capture_thread()
     _latest_frame = None
     _capture_running = True
-    _capture_thread = threading.Thread(target=_capture_thread_func, daemon=True, name="CaptureThread")
+    _capture_thread = threading.Thread(
+        target=_capture_thread_func,
+        args=(device_id,),
+        daemon=True,
+        name=f"CaptureThread-{device_id}",
+    )
     _capture_thread.start()
 
 
@@ -327,63 +342,7 @@ def _stop_capture_thread() -> None:
     global _capture_running, _capture_thread
     _capture_running = False
     if _capture_thread and _capture_thread.is_alive():
-        _capture_thread.join(timeout=1.0)
-    _capture_thread = None
-    w = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
-    h = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
-    print(f"[INFO] 摄像头已连接: {w}×{h} (设备 {device_id})")
-    return cap
-
-
-# ─── 专用抓帧线程 ─────────────────────────────────────────────────────────────
-
-def _capture_thread_func() -> None:
-    """后台专用线程：持续在同一线程内调用 cap.read()，绕开 DirectShow
-    要求 cap.read() 必须在创建 VideoCapture 的线程中调用的限制。
-    Flask MJPEG generator 只读 _latest_frame，永远不直接调用 cap.read()。
-    """
-    global _latest_frame, camera_connected, _fail_streak
-    consec_fail = 0
-    while _capture_running:
-        with camera_lock:
-            cap = camera
-        if cap is None:
-            camera_connected = False
-            time.sleep(0.05)
-            continue
-        ret, frame = cap.read()
-        if ret and frame is not None:
-            # 竖屏纠正
-            fh, fw = frame.shape[:2]
-            if fh > fw:
-                frame = cv2.rotate(frame, cv2.ROTATE_90_CLOCKWISE)
-            with _frame_lock:
-                _latest_frame = frame      # 原始帧（BGR 或 GRAY，图像原样存储）
-            camera_connected = True
-            consec_fail = 0
-            _fail_streak = 0
-        else:
-            consec_fail += 1
-            _fail_streak = consec_fail
-            if consec_fail >= 5:
-                camera_connected = False
-            time.sleep(0.03)
-
-
-def _start_capture_thread() -> None:
-    global _capture_running, _capture_thread, _latest_frame
-    _stop_capture_thread()
-    _latest_frame = None
-    _capture_running = True
-    _capture_thread = threading.Thread(target=_capture_thread_func, daemon=True, name="CaptureThread")
-    _capture_thread.start()
-
-
-def _stop_capture_thread() -> None:
-    global _capture_running, _capture_thread
-    _capture_running = False
-    if _capture_thread and _capture_thread.is_alive():
-        _capture_thread.join(timeout=1.0)
+        _capture_thread.join(timeout=2.0)
     _capture_thread = None
 
 
@@ -551,8 +510,63 @@ def detect_on_frame(frame_gray: np.ndarray):
     output_names = [o.name for o in sess.get_outputs()]
     outputs = sess.run(output_names, {sess.get_inputs()[0].name: inp})
 
-    """MJPEG 预览流。只读 _latest_frame（由 _capture_thread_func 写入），
-    绝不自己调用 cap.read()，避免 DirectShow 跨线程崩溃。"""
+    # head6 输出顺序：cv3.0 cv3.1 cv3.2 cv2.0 cv2.1 cv2.2
+    cls_outs = outputs[:3]
+    reg_outs = outputs[3:]
+    detections = _decode_yolov8(cls_outs, reg_outs)
+
+    results = []
+    for box, score, cls_id in detections:
+        x1 = max(0.0, (box[0] - pad_x) / scale)
+        y1 = max(0.0, (box[1] - pad_y) / scale)
+        x2 = min(float(w), (box[2] - pad_x) / scale)
+        y2 = min(float(h), (box[3] - pad_y) / scale)
+        results.append((x1, y1, x2, y2, score, cls_id))
+    return results
+
+
+def _save_capture(frame: np.ndarray, fmt: str) -> dict:
+    global capture_count
+    tw, th = CAPTURE_FORMATS[fmt]
+
+    if fmt == "640x360":
+        # 传感器 1280×720 → 中心裁剪 640×360
+        out = crop_center(frame, tw, th)
+    else:
+        out = frame.copy()
+
+    # 确保尺寸正确
+    if out.shape[1] != tw or out.shape[0] != th:
+        out = cv2.resize(out, (tw, th))
+
+    capture_count += 1
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    name = f"capture_{ts}_{capture_count:04d}_{fmt}.png"
+    path = os.path.join(output_dir, name)
+    cv2.imwrite(path, out)
+
+    thumb = cv2.resize(out, (160, 90 if fmt == "640x360" else 80))
+    _, buf = cv2.imencode(".jpg", thumb, [cv2.IMWRITE_JPEG_QUALITY, 72])
+    thumb_b64 = base64.b64encode(buf).decode()
+
+    info = {
+        "filename": name,
+        "format": fmt,
+        "size": f"{tw}×{th}",
+        "thumb": thumb_b64,
+        "time": datetime.now().strftime("%H:%M:%S"),
+        "index": capture_count,
+    }
+    recent_captures.appendleft(info)
+    print(f"[CAPTURE] {path}  ({tw}×{th})")
+    return info
+
+
+# ─── 视频流 ───────────────────────────────────────────────────────────────────
+
+
+def generate_frames():
+    """MJPEG 预览流。只读 _latest_frame，永远不自己调用 cap.read()。"""
     global current_fps, _frame_count, _fps_ts, camera_connected
 
     while True:
@@ -581,62 +595,8 @@ def detect_on_frame(frame_gray: np.ndarray):
             _frame_count = 0
             _fps_ts = now
 
-        # 确保 BGR 三通道（原样输出，不强制灰度）
-        if len(raw.shape) == 2:
-            disp = cv2.cvtColor(raw, cv2.COLOR_GRAY2BGR)
-        else:
-            disp = raw.copy()
-
-        h, w = disp.shape[:2]
-        cx, cy = w // 2, h // 2
-        x1, y1, x2, y2 = cx - 320, cy - 180, cx + 320, cy + 180
-        cv2.rectangle(disp, (x1, y1), (x2, y2), (45, 210, 100), 1)
-        cv2.putText(disp, "640x360 train", (x1 + 6, y1 + 20),
-                    cv2.FONT_HERSHEY_SIMPLEX, 0.52, (45, 210, 100), 1)res.appendleft(info)
-    print(f"[CAPTURE] {path}  ({tw}×{th})")
-    return info
-
-
-# ─── 视频流 ───────────────────────────────────────────────────────────────────
-
-
-def generate_frames():
-    """MJPEG 预览流。只读 _latest_frame（由 _capture_thread_func 写入），
-    绝不自己调用 cap.read()，避免 Direct只读 _latest_frame，不直接调用 cap.read()。"""
-    while True:
-        with _frame_lock:
-            raw = _latest_frame.copy() if _latest_frame is not None else None
-
-        if raw is None:
-            blk = np.zeros((CAMERA_HEIGHT, CAMERA_WIDTH, 3), dtype=np.uint8)
-            cv2.putText(blk, "No Signal", (CAMERA_WIDTH // 2 - 80, CAMERA_HEIGHT // 2),
-                        cv2.FONT_HERSHEY_SIMPLEX, 1.0, (60, 60, 60), 2)
-            _, buf = cv2.imencode(".jpg", blk, [cv2.IMWRITE_JPEG_QUALITY, 50])
-            yield (b"--frame\r\nContent-Type: image/jpeg\r\n\r\n" + buf.tobytes() + b"\r\n")
-            time.sleep(0.5)
-            continue
-
-        # YOLOv8 需要灰度输入
-        frame_gray = raw if len(raw.shape) == 2 else cv2.cvtColor(raw, cv2.COLOR_BGR2GRAY)
-        detections = detect_on_frame(frame_gray)
-        display = raw.copy() if len(raw.shape) == 3 else cv2.cvtColor(rawent-Type: image/jpeg\r\n\r\n"
-                   + buf.tobytes() + b"\r\n")
-            time.sleep(0.1)
-            continue
-
-        camera_connected = True
-        _frame_count += 1
-        now = time.time()
-        if now - _fps_ts >= 1.0:
-            current_fps = _frame_count / (now - _fps_ts)
-            _frame_count = 0
-            _fps_ts = now
-
-        # 确保 BGR 三通道（原样输出，不强制灰度）
-        if len(raw.shape) == 2:
-            disp = cv2.cvtColor(raw, cv2.COLOR_GRAY2BGR)
-        else:
-            disp = raw.copy()
+        # 确保 BGR 三通道显示（不强制灰度，保留 OSD 彩色框）
+        disp = cv2.cvtColor(raw, cv2.COLOR_GRAY2BGR) if len(raw.shape) == 2 else raw.copy()
 
         h, w = disp.shape[:2]
         cx, cy = w // 2, h // 2
@@ -653,7 +613,7 @@ def generate_frames():
 
 
 def _generate_detect_frames():
-    """YOLOv8+OSD 检测视频流（MJPEG）。只读 _latest_frame，不直接调用 cap.read()。"""
+    """YOLOv8+OSD 检测视频流（MJPEG）。只读 _latest_frame。"""
     while True:
         with _frame_lock:
             raw = _latest_frame.copy() if _latest_frame is not None else None
@@ -679,12 +639,11 @@ def _generate_detect_frames():
             label = f"{name} {score:.2f}"
             (tw, th), _ = cv2.getTextSize(label, cv2.FONT_HERSHEY_SIMPLEX, 0.5, 1)
             ty = max(int(y1) - 4, th + 4)
-         _frame_lock:
-        raw = _latest_frame.copy() if _latest_frame is not None else None
-    if raw is None:
-        return jsonify({"success": False, "error": "无法获取摄像头画面"})
-    # 统一转灰度保存（训练数据集格式）
-    frame = raw if len(raw.shape) == 2 else cv2.cvtColor(raw, cv2.COLOR_BGR2GRAY
+            cv2.rectangle(display, (int(x1), ty - th - 4), (int(x1) + tw + 4, ty), color, -1)
+            cv2.putText(display, label, (int(x1) + 2, ty - 2),
+                        cv2.FONT_HERSHEY_SIMPLEX, 0.5, (0, 0, 0), 1)
+
+        n = len(detections)
         cv2.putText(display, f"Det: {n}  conf>={_DETECT_CONF:.2f}", (8, 28),
                     cv2.FONT_HERSHEY_SIMPLEX, 0.7, (0, 200, 80), 2)
 
@@ -692,17 +651,17 @@ def _generate_detect_frames():
         yield (b"--frame\r\nContent-Type: image/jpeg\r\n\r\n" + buf.tobytes() + b"\r\n")
 
 
-# ─── 先停抓帧线程（它持有 cap 引用），再换摄像头，再重启
-    _stop_capture_thread()
-    new_cam = _try_open(device_id_global)
-    ok = new_cam is not None
-    with camera_lock:
-        _old_cam = camera  # noqa: F841 — GC 负责释放，避免并发 release
-        camera = new_cam if ok else None
-    _fail_streak = 0
-    if ok:
-        camera_connected = True
-        _start_capture_thread()ultipart/x-mixed-replace; boundary=frame")
+# ─── Flask 路由 ───────────────────────────────────────────────────────────────
+
+@app.route("/")
+def index():
+    return render_template("companion_ui.html", output_dir=output_dir)
+
+
+@app.route("/video_feed")
+def video_feed():
+    return Response(generate_frames(),
+                    mimetype="multipart/x-mixed-replace; boundary=frame")
 
 
 @app.route("/detect_feed")
@@ -735,7 +694,7 @@ def do_capture():
         raw = _latest_frame.copy() if _latest_frame is not None else None
     if raw is None:
         return jsonify({"success": False, "error": "无法获取摄像头画面"})
-    # 统一转灰度保存（训练数据集格式）
+    # 训练数据集统一转灰度保存
     frame = raw if len(raw.shape) == 2 else cv2.cvtColor(raw, cv2.COLOR_BGR2GRAY)
     info = _save_capture(frame, fmt)
     return jsonify({"success": True, **info})
@@ -743,21 +702,17 @@ def do_capture():
 
 @app.route("/refresh_camera", methods=["POST"])
 def refresh_camera():
-    global camera, _fail_streak, camera_connected
-    # 先停抓帧线程（它持有 cap 引用），再换摄像头，再重启
+    global _fail_streak, camera_connected
+    # 先停抓帧线程（它持有并在操作 cap），再重新启动
+    # 新线程会在自己线程内重新创建 VideoCapture
     _stop_capture_thread()
-    new_cam = _try_open(device_id_global)
-    ok = new_cam is not None
-    _stop_capture_thread()
-    with camera_lock:
-        _old_camera = camera  # noqa: F841 — GC 负责释放
-        camera = new_camera
-        device_id_global = new_device
     _fail_streak = 0
-    camera_connected = True
-    _start_capture_thread()刷新成功")
+    _start_capture_thread(device_id_global)
+    # 等待一下让线程尝试开栏
+    time.sleep(1.5)
+    if camera_connected:
+        print("[INFO] 摄像头手动刷新成功")
         return jsonify({"success": True, "message": "摄像头已重新连接"})
-    camera_connected = False
     print("[WARN] 摄像头刷新失败")
     return jsonify({"success": False, "error": "无法连接到摄像头设备"})
 
@@ -795,19 +750,12 @@ def switch_camera():
     except (TypeError, ValueError):
         return jsonify({"success": False, "error": "device 必须是整数"})
 
-    # 在锁外打开新摄像头，避免阻塞视频流生成器（关键修复）
-    new_camera = _try_open(new_device)
-    if new_camera is None:
-        return jsonify({"success": False, "error": "目标摄像头无法打开"})
-
+    # 先停旧抓帧线程，再刷新 device_id_global，再启动新线程
+    # 新线程在自己线程内创建新设备的 VideoCapture
     _stop_capture_thread()
-    with camera_lock:
-        _old_camera = camera  # noqa: F841 — GC 负责释放
-        camera = new_camera
-        device_id_global = new_device
+    device_id_global = new_device
     _fail_streak = 0
-    camera_connected = True
-    _start_capture_thread()
+    _start_capture_thread(new_device)
     save_preferred_device(new_device)
     print(f"[INFO] 已切换到摄像头设备 {new_device}")
     return jsonify({"success": True, "device": new_device})
@@ -818,7 +766,6 @@ def recent_captures_api():
     return jsonify(list(recent_captures))
 
 
-        _start_capture_thread()   # 启动专用抓帧线程
 @app.route("/status")
 def status():
     with camera_lock:
@@ -865,13 +812,14 @@ def main():
         else:
             print("[WARN] 未探测到可用摄像头，回退到设备 0")
 
-    print(f"[INFO] 正在连接 A1 摄像头 (设备 {selected_device})...")
-    camera = _try_open(selected_device)
-    if camera is None:
+    # 由报帧线程内部创建 VideoCapture，满足 DirectShow 同线程要求
+    print(f"[INFO] 正在启动抓帧线程 (设备 {selected_device})...")
+    save_preferred_device(selected_device)
+    _start_capture_thread(selected_device)
+    # 等待线程开栏
+    time.sleep(1.0)
+    if not camera_connected:
         print("[WARN] 摄像头未连接，工具仍可启动，请连接后点击「刷新摄像头」")
-    else:
-        save_preferred_device(selected_device)
-        _start_capture_thread()   # 启动专用抓帧线程
 
     print(f"[INFO] Aurora Companion 已启动: http://localhost:{args.port}")
     print(f"[INFO] 快捷键: 1=1280×720  2=640×360  R=刷新摄像头")

--- a/tools/aurora/launch_a1_viewer.ps1
+++ b/tools/aurora/launch_a1_viewer.ps1
@@ -1,0 +1,52 @@
+param(
+    [int]$Device   = -1,
+    [int]$Port     = 5802,
+    [switch]$NoBrowser
+)
+
+$ErrorActionPreference = "Stop"
+
+try { & chcp.com 65001 | Out-Null } catch {}
+$Utf8 = New-Object System.Text.UTF8Encoding($false)
+[Console]::InputEncoding  = $Utf8
+[Console]::OutputEncoding = $Utf8
+$OutputEncoding           = $Utf8
+$env:PYTHONUTF8           = "1"
+$env:PYTHONIOENCODING     = "utf-8"
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+Set-Location $ScriptDir
+
+if (-not (Test-Path "a1_viewer.py")) {
+    Write-Error "未找到 a1_viewer.py，请在 tools/aurora/ 目录运行本脚本。"
+    exit 1
+}
+
+# 查找 Python（优先 .venv39）
+$PythonCandidates = @(
+    (Resolve-Path "..\..\\.venv39\Scripts\python.exe" -ErrorAction SilentlyContinue),
+    (Resolve-Path "..\..\.venv39\Scripts\python.exe"  -ErrorAction SilentlyContinue),
+    "python"
+) | Where-Object { $_ }
+
+$Python = $null
+foreach ($c in $PythonCandidates) {
+    try {
+        $ver = & $c --version 2>&1
+        if ($ver -match "Python 3") { $Python = $c; break }
+    } catch {}
+}
+if (-not $Python) { $Python = "python" }
+Write-Host "[INFO] Python: $Python"
+
+$Args_ = @("a1_viewer.py", "--port", $Port)
+if ($Device -ge 0) { $Args_ += "--device", $Device }
+
+if (-not $NoBrowser) {
+    $Url = "http://localhost:$Port"
+    Start-Process $Url
+    Write-Host "[INFO] 浏览器将打开: $Url"
+}
+
+Write-Host "[INFO] 启动 A1 Viewer (端口 $Port)..."
+& $Python @Args_

--- a/tools/aurora/requirements.txt
+++ b/tools/aurora/requirements.txt
@@ -3,3 +3,4 @@ opencv-python
 Pillow
 flask
 pyserial
+onnxruntime

--- a/tools/aurora/templates/a1_viewer.html
+++ b/tools/aurora/templates/a1_viewer.html
@@ -1,0 +1,569 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+<title>A1 Viewer — YOLOv8 OSD 结果显示</title>
+<style>
+:root {
+  --bg:      #06111a;
+  --surface: #0d1f2d;
+  --card:    #112436;
+  --border:  #1e3a50;
+  --text:    #e8f4ff;
+  --muted:   #6a97b3;
+  --blue:    #2fb6ff;
+  --green:   #26d97f;
+  --amber:   #f0b030;
+  --red:     #ff5757;
+  --purple:  #9d8bff;
+  --radius:  12px;
+}
+* { margin:0; padding:0; box-sizing:border-box; }
+html, body {
+  height: 100%;
+  background: var(--bg);
+  color: var(--text);
+  font-family: 'Segoe UI', 'Noto Sans SC', sans-serif;
+  overflow: hidden;
+}
+
+/* ── Layout ── */
+.app {
+  display: grid;
+  grid-template-rows: 52px 1fr;
+  grid-template-columns: 1fr 320px;
+  height: 100vh;
+  gap: 0;
+}
+
+/* ── Header ── */
+header {
+  grid-column: 1 / -1;
+  background: rgba(13,31,45,.96);
+  border-bottom: 1px solid var(--border);
+  backdrop-filter: blur(12px);
+  display: flex;
+  align-items: center;
+  padding: 0 18px;
+  gap: 16px;
+  box-shadow: 0 4px 20px rgba(0,0,0,.4);
+  z-index: 100;
+}
+.logo {
+  display:flex; align-items:center; gap:8px;
+  font-weight: 700; font-size: 1.05em;
+  background: linear-gradient(90deg, var(--blue), #00d1c7);
+  -webkit-background-clip: text; -webkit-text-fill-color: transparent;
+}
+.logo svg { flex-shrink:0; }
+.spacer { flex: 1; }
+
+/* Status pill */
+.status-pill {
+  display: flex; align-items: center; gap: 6px;
+  background: rgba(17,36,54,.8);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  padding: 4px 14px;
+  font-size: .82em;
+}
+.dot {
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--red);
+  transition: background .4s;
+}
+.dot.connected { background: var(--green); box-shadow: 0 0 6px var(--green); }
+#fps-badge {
+  background: rgba(47,182,255,.12);
+  border: 1px solid rgba(47,182,255,.25);
+  border-radius: 16px;
+  padding: 3px 12px;
+  font-size: .8em;
+  color: var(--blue);
+  font-variant-numeric: tabular-nums;
+}
+
+/* Reconnect button */
+.btn {
+  padding: 6px 18px;
+  border: none; border-radius: 8px;
+  font-size: .83em; font-weight: 600;
+  cursor: pointer;
+  background: linear-gradient(135deg, var(--blue), #0080cc);
+  color: #fff;
+  transition: opacity .15s, transform .1s;
+}
+.btn:active { transform: scale(.97); opacity: .85; }
+.btn:disabled { opacity: .45; cursor: not-allowed; }
+
+/* Fullscreen button */
+.btn-ghost {
+  padding: 6px 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: transparent;
+  color: var(--muted);
+  font-size: .82em; font-weight: 600;
+  cursor: pointer;
+  transition: border-color .15s, color .15s;
+}
+.btn-ghost:hover { border-color: var(--blue); color: var(--blue); }
+
+/* ── Main video panel ── */
+.video-panel {
+  background: #020d15;
+  position: relative;
+  overflow: hidden;
+  display: flex; align-items: center; justify-content: center;
+}
+#stream-img {
+  max-width: 100%; max-height: 100%;
+  object-fit: contain;
+  display: block;
+  transition: opacity .2s;
+}
+.overlay-label {
+  position: absolute;
+  top: 14px; left: 14px;
+  background: rgba(0,0,0,.55);
+  backdrop-filter: blur(6px);
+  border: 1px solid rgba(47,182,255,.25);
+  border-radius: 6px;
+  padding: 4px 10px;
+  font-size: .78em;
+  color: var(--muted);
+  pointer-events: none;
+  display: flex; align-items: center; gap: 6px;
+}
+.overlay-label span { color: var(--blue); font-weight: 600; }
+
+/* No-signal overlay */
+#no-signal {
+  position: absolute;
+  inset: 0;
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: center;
+  gap: 12px;
+  background: rgba(3,10,18,.85);
+  z-index: 10;
+  transition: opacity .3s;
+}
+#no-signal.hidden { opacity: 0; pointer-events: none; }
+#no-signal svg { opacity: .35; }
+#no-signal p { color: var(--muted); font-size: .9em; }
+#no-signal h2 { font-size: 1.3em; color: var(--text); font-weight: 600; }
+
+/* ── Side panel ── */
+.side-panel {
+  background: var(--surface);
+  border-left: 1px solid var(--border);
+  display: flex; flex-direction: column;
+  overflow-y: auto;
+  overflow-x: hidden;
+  gap: 0;
+}
+.side-section {
+  border-bottom: 1px solid var(--border);
+  padding: 14px 16px;
+}
+.side-section-title {
+  font-size: .75em;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .08em;
+  color: var(--muted);
+  margin-bottom: 10px;
+  display: flex; align-items: center; gap: 6px;
+}
+.side-section-title .badge {
+  background: rgba(47,182,255,.12);
+  border: 1px solid rgba(47,182,255,.2);
+  border-radius: 10px;
+  padding: 1px 7px;
+  font-size: .8em;
+  color: var(--blue);
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+/* Info grid */
+.info-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
+.info-card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 10px 12px;
+}
+.info-card .label { font-size: .72em; color: var(--muted); }
+.info-card .value {
+  font-size: 1.15em; font-weight: 700;
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+  margin-top: 2px;
+}
+.info-card .value.green { color: var(--green); }
+.info-card .value.amber { color: var(--amber); }
+.info-card .value.red   { color: var(--red); }
+
+/* ── 3D Point Cloud placeholder ── */
+#pointcloud-canvas-wrap {
+  width: 100%;
+  aspect-ratio: 4/3;
+  background: #08141e;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  position: relative;
+  overflow: hidden;
+  display: flex; align-items: center; justify-content: center;
+}
+#pointcloud-canvas {
+  width: 100%; height: 100%;
+  display: block;
+}
+.pc-placeholder {
+  position: absolute; inset: 0;
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: center;
+  gap: 8px;
+  color: var(--muted);
+  font-size: .8em;
+  pointer-events: none;
+}
+.pc-placeholder .title { color: var(--text); font-size: .95em; font-weight: 600; }
+
+/* Future extension tabs */
+.ext-tabs {
+  display: flex; gap: 6px; flex-wrap: wrap;
+  margin-bottom: 10px;
+}
+.ext-tab {
+  padding: 4px 12px;
+  border-radius: 20px;
+  border: 1px solid var(--border);
+  font-size: .75em; font-weight: 600;
+  cursor: pointer; background: transparent; color: var(--muted);
+  transition: all .15s;
+}
+.ext-tab.active { background: rgba(47,182,255,.12); border-color: var(--blue); color: var(--blue); }
+
+/* Scrollbar */
+.side-panel::-webkit-scrollbar { width: 4px; }
+.side-panel::-webkit-scrollbar-track { background: transparent; }
+.side-panel::-webkit-scrollbar-thumb { background: var(--border); border-radius: 4px; }
+
+/* Mobile / tablet adjust */
+@media (max-width: 900px) {
+  .app {
+    grid-template-columns: 1fr;
+    grid-template-rows: 52px 1fr auto;
+  }
+  .side-panel {
+    border-left: none;
+    border-top: 1px solid var(--border);
+    max-height: 45vh;
+  }
+}
+
+/* Fullscreen mode */
+.video-panel:fullscreen { background: #000; }
+.video-panel:fullscreen #stream-img { max-width: 100%; max-height: 100%; }
+</style>
+</head>
+<body>
+<div class="app">
+
+  <!-- ── Header ── -->
+  <header>
+    <div class="logo">
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none">
+        <rect width="24" height="24" rx="6"
+              fill="url(#hg)"/>
+        <path d="M7 17L12 7L17 17" stroke="#fff" stroke-width="1.8"
+              stroke-linecap="round" stroke-linejoin="round"/>
+        <circle cx="12" cy="7" r="1.5" fill="#fff"/>
+        <defs>
+          <linearGradient id="hg" x1="0" y1="0" x2="24" y2="24">
+            <stop offset="0%" stop-color="#2fb6ff"/>
+            <stop offset="100%" stop-color="#ff8a3d"/>
+          </linearGradient>
+        </defs>
+      </svg>
+      A1 Viewer
+    </div>
+
+    <div class="status-pill">
+      <span class="dot" id="conn-dot"></span>
+      <span id="conn-text">Disconnected</span>
+    </div>
+
+    <div id="fps-badge">-- FPS</div>
+
+    <div class="spacer"></div>
+
+    <button class="btn-ghost" id="btn-fullscreen" title="全屏">⛶ Fullscreen</button>
+    <button class="btn" id="btn-reconnect">Reconnect</button>
+  </header>
+
+  <!-- ── Video Panel ── -->
+  <div class="video-panel" id="video-panel">
+    <img id="stream-img" src="/stream" alt="A1 stream"
+         onload="onStreamLoad()" onerror="onStreamError()">
+
+    <div class="overlay-label">
+      A1 NPU · YOLOv8+OSD · <span id="res-label">1280×720</span>
+    </div>
+
+    <!-- No-signal overlay -->
+    <div id="no-signal">
+      <svg width="56" height="56" viewBox="0 0 24 24" fill="none">
+        <circle cx="12" cy="12" r="10" stroke="#6a97b3" stroke-width="1.5"/>
+        <path d="M8 12h8M12 8v8" stroke="#6a97b3" stroke-width="1.5"
+              stroke-linecap="round" transform="rotate(45 12 12)"/>
+      </svg>
+      <h2>等待 A1 信号</h2>
+      <p>请通过 USB 连接 A1 开发板，然后点击 Reconnect</p>
+    </div>
+  </div>
+
+  <!-- ── Side Panel ── -->
+  <aside class="side-panel">
+
+    <!-- Status cards -->
+    <div class="side-section">
+      <div class="side-section-title">系统状态</div>
+      <div class="info-grid">
+        <div class="info-card">
+          <div class="label">连接状态</div>
+          <div class="value" id="sc-conn">—</div>
+        </div>
+        <div class="info-card">
+          <div class="label">帧率</div>
+          <div class="value" id="sc-fps">— fps</div>
+        </div>
+        <div class="info-card">
+          <div class="label">设备</div>
+          <div class="value" id="sc-dev">—</div>
+        </div>
+        <div class="info-card">
+          <div class="label">分辨率</div>
+          <div class="value" id="sc-res">—</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- 3D Point Cloud panel -->
+    <div class="side-section">
+      <div class="side-section-title">
+        3D 点云
+        <span class="badge">预留接口</span>
+      </div>
+      <div id="pointcloud-canvas-wrap">
+        <canvas id="pointcloud-canvas"></canvas>
+        <div class="pc-placeholder" id="pc-placeholder">
+          <svg width="36" height="36" viewBox="0 0 24 24" fill="none">
+            <circle cx="5" cy="19" r="2" fill="#1e3a50"/>
+            <circle cx="12" cy="5"  r="2" fill="#1e3a50"/>
+            <circle cx="19" cy="14" r="2" fill="#1e3a50"/>
+            <circle cx="8"  cy="12" r="1.5" fill="#1e3a50"/>
+            <circle cx="16" cy="9"  r="1.5" fill="#1e3a50"/>
+          </svg>
+          <span class="title">3D 点云显示</span>
+          <span>调用 /api/pointcloud 获取数据</span>
+          <span>Three.js 渲染，待接入传感器</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Future extensions -->
+    <div class="side-section">
+      <div class="side-section-title">
+        扩展面板
+        <span class="badge">可开发</span>
+      </div>
+      <div class="ext-tabs">
+        <button class="ext-tab active">点云</button>
+        <button class="ext-tab">雷达</button>
+        <button class="ext-tab">遥测</button>
+        <button class="ext-tab">控制</button>
+      </div>
+      <div style="color:var(--muted);font-size:.78em;line-height:1.6">
+        各面板通过以下 API 扩展：<br>
+        <code style="color:var(--blue)">/api/pointcloud</code> — 点云数据<br>
+        <code style="color:var(--blue)">/api/telemetry</code> — 底盘遥测<br>
+        <code style="color:var(--blue)">/stream</code> — MJPEG 视频<br>
+        <br>
+        可在
+        <code style="color:var(--purple)">a1_viewer.py</code>
+        中添加 WebSocket / SSE 端点接入实时数据流。
+      </div>
+    </div>
+
+    <!-- About -->
+    <div class="side-section" style="margin-top:auto">
+      <div style="color:var(--muted);font-size:.75em;line-height:1.7">
+        <b style="color:var(--text)">A1 Viewer v1.0</b><br>
+        板端推理：SC132GS + M1 NPU<br>
+        模型：YOLOv8 head6 (640×360)<br>
+        OSD：SmartSens 硬件叠加层<br>
+        PC端：仅显示，不做本地推理
+      </div>
+    </div>
+
+  </aside>
+</div>
+
+<script>
+// ── Three.js 点云占位动画（展示扩展能力）──────────────────────────────
+(function initPointCloudDemo() {
+  const canvas = document.getElementById('pointcloud-canvas');
+  const wrap   = document.getElementById('pointcloud-canvas-wrap');
+  const ph     = document.getElementById('pc-placeholder');
+
+  // 简单 Canvas 2D 演示动画（占位，真实实现用 Three.js WebGL）
+  const ctx = canvas.getContext('2d');
+  let raf, t = 0;
+
+  function resize() {
+    canvas.width  = wrap.clientWidth;
+    canvas.height = wrap.clientHeight;
+  }
+  resize();
+  new ResizeObserver(resize).observe(wrap);
+
+  // 生成占位点集
+  const pts = Array.from({length: 120}, () => ({
+    x: (Math.random() - .5) * 1.6,
+    y: (Math.random() - .5) * 1.2,
+    z: Math.random() * 2,
+    vx: (Math.random() - .5) * .002,
+    vy: (Math.random() - .5) * .002,
+  }));
+
+  function project(x, y, z, cx, cy) {
+    const fov = 2.2;
+    const s   = fov / (fov + z);
+    return { px: cx + x * s * cy * .7, py: cy + y * s * cy, s };
+  }
+
+  function draw() {
+    const W = canvas.width, H = canvas.height;
+    const cx = W / 2, cy = H / 2;
+    ctx.clearRect(0, 0, W, H);
+    t += .008;
+    pts.forEach(p => {
+      p.x += p.vx; p.y += p.vy;
+      if (Math.abs(p.x) > .8) p.vx *= -1;
+      if (Math.abs(p.y) > .6) p.vy *= -1;
+      const rx  = p.x * Math.cos(t) - p.z * .3 * Math.sin(t);
+      const { px, py, s } = project(rx, p.y, p.z + 1, cx, cy);
+      const r = Math.max(1, s * 3);
+      const alpha = .15 + s * .45;
+      ctx.beginPath();
+      ctx.arc(px, py, r, 0, Math.PI * 2);
+      ctx.fillStyle = `rgba(47,182,255,${alpha.toFixed(2)})`;
+      ctx.fill();
+    });
+    raf = requestAnimationFrame(draw);
+  }
+
+  // 隐藏占位文字，显示动画
+  ph.style.display = 'none';
+  draw();
+})();
+
+
+// ── 状态轮询 ────────────────────────────────────────────────────────────
+let streamOK = false;
+
+function onStreamLoad() {
+  streamOK = true;
+  document.getElementById('no-signal').classList.add('hidden');
+}
+function onStreamError() {
+  streamOK = false;
+  document.getElementById('no-signal').classList.remove('hidden');
+}
+
+async function pollStatus() {
+  try {
+    const r  = await fetch('/status');
+    const st = await r.json();
+
+    const dot       = document.getElementById('conn-dot');
+    const connText  = document.getElementById('conn-text');
+    const fpsBadge  = document.getElementById('fps-badge');
+    const scConn    = document.getElementById('sc-conn');
+    const scFps     = document.getElementById('sc-fps');
+    const scDev     = document.getElementById('sc-dev');
+    const scRes     = document.getElementById('sc-res');
+    const resLabel  = document.getElementById('res-label');
+    const noSignal  = document.getElementById('no-signal');
+
+    if (st.connected) {
+      dot.classList.add('connected');
+      connText.textContent = 'Connected';
+      scConn.textContent   = 'Connected';
+      scConn.className     = 'value green';
+      noSignal.classList.add('hidden');
+    } else {
+      dot.classList.remove('connected');
+      connText.textContent = 'Disconnected';
+      scConn.textContent   = 'Disconnected';
+      scConn.className     = 'value red';
+      if (!streamOK) noSignal.classList.remove('hidden');
+    }
+
+    fpsBadge.textContent = `${st.fps} FPS`;
+    scFps.textContent    = `${st.fps} fps`;
+    scFps.className      = st.fps >= 20 ? 'value green' : st.fps >= 10 ? 'value amber' : 'value red';
+    scDev.textContent    = `dev ${st.device}`;
+    scRes.textContent    = st.resolution;
+    resLabel.textContent = st.resolution;
+
+  } catch (_) { /* network error, ignore */ }
+}
+
+setInterval(pollStatus, 1500);
+pollStatus();
+
+
+// ── Reconnect ───────────────────────────────────────────────────────────
+document.getElementById('btn-reconnect').addEventListener('click', async function() {
+  this.disabled = true;
+  this.textContent = 'Reconnecting…';
+  try {
+    await fetch('/reconnect', { method: 'POST' });
+    // Reload the img src to restart MJPEG stream
+    const img = document.getElementById('stream-img');
+    img.src = '/stream?' + Date.now();
+  } catch (_) {}
+  setTimeout(() => {
+    this.disabled    = false;
+    this.textContent = 'Reconnect';
+    pollStatus();
+  }, 2000);
+});
+
+
+// ── Fullscreen ──────────────────────────────────────────────────────────
+document.getElementById('btn-fullscreen').addEventListener('click', () => {
+  const panel = document.getElementById('video-panel');
+  if (!document.fullscreenElement) {
+    panel.requestFullscreen?.();
+  } else {
+    document.exitFullscreen?.();
+  }
+});
+
+
+// ── Extension tabs (UI only) ────────────────────────────────────────────
+document.querySelectorAll('.ext-tab').forEach(btn => {
+  btn.addEventListener('click', () => {
+    document.querySelectorAll('.ext-tab').forEach(b => b.classList.remove('active'));
+    btn.classList.add('active');
+  });
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## 问题根因

**黑屏根本原因**：VideoCapture 在 main() 线程中创建，但 Flask 	hreaded=True 把 MJPEG generator 分配到 worker 线程，导致 cap.read() 在另一个 OS 线程中被调用。DirectShow 规定创建和读取必须在同一线程，违反后第一帧后所有 read 返回 False → 黑屏。

## 修复（aurora_companion.py）

- **核心架构**：新增专用 \CaptureThread\，在线程内部调用 \_try_open()\ 创建 \VideoCapture\，只有这一个线程调用 \cap.read()\
- Flask MJPEG generator / \do_capture\ 只读 \_latest_frame\（用 \_frame_lock\ 保护）
- \efresh_camera\ / \switch_camera\ 通过 \_stop/_start_capture_thread\ 重启线程
- 去除强制灰度：原始帧（BGR）存储，显示保留彩色（OSD 框保留），仅推理/保存时转灰度
- 移除 FPS/BUFFERSIZE CAP_PROP\_*（部分 DirectShow 驱动处理有 bug）

## 新增（A1 Viewer）

| 文件 | 说明 |
|------|------|
| \	ools/aurora/a1_viewer.py\ | 极简 Flask 流转发，端口 5802，板端推理已完成无需本地 AI |
| \	ools/aurora/templates/a1_viewer.html\ | 平板友好全屏显示界面，含 3D 点云占位（Three.js 扩展接口） |
| \	ools/aurora/launch_a1_viewer.ps1\ | 一键启动，自动打开浏览器 |

### A1 Viewer 设计

\\\
A1 开发板 USB-UVC
  └─ SC132GS 1280×720 Y8
  └─ M1 NPU → YOLOv8 head6 (640×360)
  └─ 硬件 OSD → BGR 帧（框已烧入）
        │ USB
PC: a1_viewer.py
  └─ CaptureThread: cap.read() → _latest_frame
  └─ Flask /stream: MJPEG 转发（不做推理）
        │ HTTP MJPEG
浏览器 / 平板: a1_viewer.html
  └─ 全屏视频面板
  └─ 3D 点云面板（/api/pointcloud 预留接口）
  └─ 底盘遥测面板（/api/telemetry 预留接口）
\\\

### 扩展接口

- \/api/pointcloud\ — 接入 LiDAR/深度传感器数据（Three.js）
- \/api/telemetry\ — 接入底盘速度/IMU/电量
- \/reconnect\ POST — 重连摄像头

## 文档

更新 \docs/06_程序概览.md\：补充 A1 Viewer 架构、API 表格、专用抓帧线程说明