### PR TITLE
Fix Aurora camera enumeration and startup flow

### DIFF
--- a/data/A1_SDK_SC132GS/smartsens_sdk/smart_software/src/app_demo/face_detection/ssne_ai_demo/include/osd-device.hpp
+++ b/data/A1_SDK_SC132GS/smartsens_sdk/smart_software/src/app_demo/face_detection/ssne_ai_demo/include/osd-device.hpp
@@ -41,14 +41,15 @@ private:
     void GenQrangleBox(std::array<float, 4>& det, int border);
 
 private:
-    handle_t m_osd_handle;
+    handle_t m_osd_handle{};
     std::string m_osd_lut_path = "/app_demo/app_assets/colorLUT.sscl";
     // std::string m_texture_path = "/ai/imgs/test_24.ssbmp";
     uint8_t *m_pcolor_lut = nullptr;
     int m_file_size = 0;
-    int m_height, m_width;
+    int m_height = 0;
+    int m_width = 0;
     
-    fdevice::DMA_BUFFER_ATTR_S m_layer_dma[OSD_LAYER_SIZE];
+    fdevice::DMA_BUFFER_ATTR_S m_layer_dma[OSD_LAYER_SIZE]{};
     fdevice::VERTEXS_S m_qrangle_out={0}, m_qrangle_in={0};
 };
 

--- a/data/A1_SDK_SC132GS/smartsens_sdk/smart_software/src/app_demo/face_detection/ssne_ai_demo/include/utils.hpp
+++ b/data/A1_SDK_SC132GS/smartsens_sdk/smart_software/src/app_demo/face_detection/ssne_ai_demo/include/utils.hpp
@@ -15,6 +15,8 @@ namespace utils {
   void NMS(FaceDetectionResult* result, float iou_threshold, int top_k);
 } // namespace utils
 
+constexpr int DETECTION_LAYER_ID = 0;
+
 class VISUALIZER {
   public:
     void Initialize(std::array<int, 2>& in_img_shape);

--- a/data/A1_SDK_SC132GS/smartsens_sdk/smart_software/src/app_demo/face_detection/ssne_ai_demo/src/osd-device.cpp
+++ b/data/A1_SDK_SC132GS/smartsens_sdk/smart_software/src/app_demo/face_detection/ssne_ai_demo/src/osd-device.cpp
@@ -91,7 +91,7 @@ void OsdDevice::Release(){
     }
 
     if(m_pcolor_lut != nullptr){
-        delete m_pcolor_lut;
+        delete[] m_pcolor_lut;
         m_pcolor_lut = nullptr;
     }
 

--- a/tools/aurora/a1_companion.py
+++ b/tools/aurora/a1_companion.py
@@ -6,8 +6,27 @@
 方便和现有 Aurora 伴侣工具并行调试。
 """
 
+import os
 from pathlib import Path
 import sys
+
+
+def _resolve_local_port(argv):
+    for index, argument in enumerate(argv):
+        if argument.startswith("--port="):
+            try:
+                return int(argument.split("=", 1)[1])
+            except ValueError:
+                break
+        if argument == "--port" and index + 1 < len(argv):
+            try:
+                return int(argv[index + 1])
+            except ValueError:
+                break
+    return 5803
+
+
+os.environ.setdefault("A1_COMPANION_URL", f"http://127.0.0.1:{_resolve_local_port(sys.argv[1:])}")
 
 import aurora_companion as base
 

--- a/tools/aurora/aurora_companion.py
+++ b/tools/aurora/aurora_companion.py
@@ -90,6 +90,8 @@ camera: Optional[cv2.VideoCapture] = None
 camera_lock = threading.Lock()
 device_id_global = 0
 camera_source_global = "auto"
+camera_bootstrap_active = False
+camera_devices_snapshot: list = []
 output_dir: str = ""
 capture_count = 0
 recent_captures: deque = deque(maxlen=8)
@@ -176,7 +178,10 @@ def _source_label(source: str) -> str:
 
 
 def _infer_device_source(info: dict) -> str:
-    if info.get("supports_gray_fourcc") or info.get("is_grayscale"):
+    if info.get("supports_gray_fourcc"):
+        return CAMERA_SOURCE_A1
+    # 仅当帧有实际内容时才凭灰度特征判断为 A1；全黑帧 (0==0==0) 不能作为依据
+    if info.get("is_grayscale") and info.get("has_content"):
         return CAMERA_SOURCE_A1
     return CAMERA_SOURCE_WINDOWS
 
@@ -272,6 +277,7 @@ def probe_camera_device(device_id: int) -> dict:
             cv2.VideoWriter_fourcc(*"Y800"),
             cv2.VideoWriter_fourcc(*"GREY"),
             cv2.VideoWriter_fourcc(*"Y8  "),
+            cv2.VideoWriter_fourcc(*"Y16 "),
         ]
         supports_gray_fourcc = False
         for fourcc in gray_fourccs:
@@ -283,6 +289,9 @@ def probe_camera_device(device_id: int) -> dict:
 
         cap.set(cv2.CAP_PROP_FRAME_WIDTH, CAMERA_WIDTH)
         cap.set(cv2.CAP_PROP_FRAME_HEIGHT, CAMERA_HEIGHT)
+        # 丢弃前几帧：DirectShow 管道初始化期间第 1 帧通常为全黑
+        for _ in range(3):
+            cap.read()
         ret, frame = cap.read()
         actual_w = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
         actual_h = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
@@ -323,7 +332,8 @@ def probe_camera_device(device_id: int) -> dict:
     elif frame_w == 640 and frame_h == 360:
         score += 2
     if frame_w == 360 and frame_h == 1280:
-        score += 5
+        # 竖向 portrait 帧：SC132GS 不应以此分辨率输出，通常是分辨率协商失败的产物
+        score -= 4
     if frame_w == 720 and frame_h == 1280:
         score += 4
     if is_grayscale:
@@ -337,7 +347,11 @@ def probe_camera_device(device_id: int) -> dict:
     if frame_w == CAMERA_WIDTH and frame_h == CAMERA_HEIGHT and (not is_grayscale) and (not supports_gray_fourcc):
         score -= 3
 
-    source = _infer_device_source({"supports_gray_fourcc": supports_gray_fourcc, "is_grayscale": is_grayscale})
+    source = _infer_device_source({
+        "supports_gray_fourcc": supports_gray_fourcc,
+        "is_grayscale": is_grayscale,
+        "has_content": has_content,
+    })
 
     return {
         "id": device_id,
@@ -408,6 +422,72 @@ def open_camera(device_id: int, source: str = CAMERA_SOURCE_AUTO) -> Optional[cv
     if w != CAMERA_WIDTH or h != CAMERA_HEIGHT:
         print(f"[WARN] 实际分辨率 {w}×{h} 与预期 {CAMERA_WIDTH}×{CAMERA_HEIGHT} 不匹配")
     return cap
+
+
+def bootstrap_camera(requested_device: int) -> None:
+    """在后台完成摄像头自动探测与打开，避免阻塞 Web 服务启动。"""
+    global camera, device_id_global, camera_source_global, camera_connected, _fail_streak, _consecutive_failures
+    global camera_bootstrap_active, camera_devices_snapshot
+
+    camera_bootstrap_active = True
+    try:
+        selected_device, candidates = choose_camera_device(requested_device)
+        if candidates:
+            selected_info = next((c for c in candidates if c["id"] == selected_device), None)
+            if selected_info is None:
+                selected_info = probe_camera_device(selected_device)
+        else:
+            selected_info = probe_camera_device(selected_device)
+
+        camera_devices_snapshot = list(candidates) if candidates else [selected_info]
+
+        camera_source_global = selected_info.get("source", CAMERA_SOURCE_WINDOWS)
+        device_id_global = selected_device
+
+        if requested_device < 0:
+            if candidates:
+                print("[INFO] 自动探测摄像头结果（按优先级）:")
+                for c in candidates:
+                    kind = "Gray" if c.get("is_grayscale") else "Color"
+                    y8 = "Y8" if c.get("supports_gray_fourcc") else "NoY8"
+                    print(f"  - device {c['id']}: {c['actual_width']}x{c['actual_height']} {kind} {y8} score={c['score']} source={c.get('source', CAMERA_SOURCE_WINDOWS)}")
+                print(f"[INFO] 自动选择设备: {selected_device} source={camera_source_global}")
+            else:
+                print("[WARN] 未探测到可用摄像头，回退到设备 0")
+
+        print(f"[INFO] 正在连接摄像头 (设备 {selected_device}, source={camera_source_global})...")
+        save_preferred_device(selected_device)
+        try:
+            opened_camera = open_camera(selected_device, camera_source_global)
+        except Exception as e:
+            print(f"[WARN] 摄像头打开失败: {e}，工具仍可启动，请连接后点击「刷新摄像头」")
+            opened_camera = None
+
+        # 到这里 snapshot 已设置，/camera_devices 可正常应答，再做初始帧预热
+        if opened_camera is not None and opened_camera.isOpened():
+            print("[INFO] 刷新 DirectShow 初始化队列帧...")
+            with _suppress_c_stderr():
+                for _ in range(5):
+                    opened_camera.read()
+
+        with camera_lock:
+            if camera:
+                camera.release()
+            camera = opened_camera
+
+        camera_connected = opened_camera is not None and opened_camera.isOpened()
+        if camera_connected:
+            _fail_streak = 0
+            _consecutive_failures = 0
+    except Exception as e:
+        print(f"[WARN] 摄像头后台初始化失败: {e}")
+        with camera_lock:
+            if camera:
+                camera.release()
+            camera = None
+        camera_connected = False
+    finally:
+        camera_bootstrap_active = False
 
 
 def _read_display_frame(cap: cv2.VideoCapture) -> Optional[np.ndarray]:
@@ -922,7 +1002,8 @@ def generate_frames():
             _fail_streak += 1
             _consecutive_failures += 1
             now = time.time()
-            if (_consecutive_failures >= FAIL_THRESHOLD
+            if (not camera_bootstrap_active
+                    and _consecutive_failures >= FAIL_THRESHOLD
                     and now - _last_reconnect_time > RECONNECT_INTERVAL):
                 _last_reconnect_time = now
                 _consecutive_failures = 0
@@ -1151,7 +1232,17 @@ def refresh_camera():
 
 @app.route("/camera_devices")
 def camera_devices():
-    devices = list_camera_devices()
+    global camera_devices_snapshot
+
+    bootstrapping = False
+    if camera_devices_snapshot:
+        devices = list(camera_devices_snapshot)
+    elif camera_bootstrap_active:
+        devices = []
+        bootstrapping = True
+    else:
+        devices = list_camera_devices()
+        camera_devices_snapshot = list(devices)
     items = []
     for d in devices:
         kind = "Gray" if d.get("is_grayscale") else "Color"
@@ -1172,6 +1263,7 @@ def camera_devices():
         "current_device": device_id_global,
         "current_source": camera_source_global,
         "devices": items,
+        "bootstrapping": bootstrapping,
     })
 
 
@@ -1264,37 +1356,10 @@ def main():
     os.makedirs(output_dir, exist_ok=True)
     print(f"[INFO] 输出目录: {output_dir}")
 
-    selected_device, candidates = choose_camera_device(args.device)
-    device_id_global = selected_device
-    if candidates:
-        selected_info = next((c for c in candidates if c["id"] == selected_device), None)
-        if selected_info is None:
-            selected_info = probe_camera_device(selected_device)
-    else:
-        selected_info = probe_camera_device(selected_device)
-    camera_source_global = selected_info.get("source", CAMERA_SOURCE_WINDOWS)
-
-    if args.device < 0:
-        if candidates:
-            print("[INFO] 自动探测摄像头结果（按优先级）:")
-            for c in candidates:
-                kind = "Gray" if c.get("is_grayscale") else "Color"
-                y8 = "Y8" if c.get("supports_gray_fourcc") else "NoY8"
-                print(f"  - device {c['id']}: {c['actual_width']}x{c['actual_height']} {kind} {y8} score={c['score']} source={c.get('source', CAMERA_SOURCE_WINDOWS)}")
-            print(f"[INFO] 自动选择设备: {selected_device} source={camera_source_global}")
-        else:
-            print("[WARN] 未探测到可用摄像头，回退到设备 0")
-
-    print(f"[INFO] 正在连接摄像头 (设备 {selected_device}, source={camera_source_global})...")
-    save_preferred_device(selected_device)
-    try:
-        camera = open_camera(selected_device, camera_source_global)
-    except Exception as e:
-        print(f"[WARN] 摄像头打开失败: {e}，工具仍可启动，请连接后点击「刷新摄像头」")
-        camera = None
-
-    print(f"[INFO] Aurora Companion 已启动: http://127.0.0.1:{args.port}")
+    print(f"[INFO] Aurora Companion 正在启动 Web 服务: http://127.0.0.1:{args.port}")
     print(f"[INFO] 快捷键: 1=1280×720  2=640×360  R=刷新摄像头")
+    camera_bootstrap = threading.Thread(target=bootstrap_camera, args=(args.device,), daemon=True)
+    camera_bootstrap.start()
     app.run(host=args.host, port=args.port, debug=False, threaded=True)
 
 

--- a/tools/aurora/launch.ps1
+++ b/tools/aurora/launch.ps1
@@ -66,33 +66,38 @@ function Start-BrowserWhenReady {
     )
 
     try {
-        Start-Job -ScriptBlock {
-            param([string]$TargetUrl, [int]$TargetPort)
+        $browserWorker = @'
+$deadline = [DateTime]::UtcNow.AddSeconds(180)
+while ([DateTime]::UtcNow -lt $deadline) {
+    try {
+        $client = New-Object System.Net.Sockets.TcpClient
+        $async = $client.BeginConnect("127.0.0.1", __PORT__, $null, $null)
+        if ($async.AsyncWaitHandle.WaitOne(250)) {
+            $client.EndConnect($async)
+            $client.Close()
+            Start-Process "__URL__" | Out-Null
+            exit 0
+        }
+        $client.Close()
+    }
+    catch {
+    }
+    Start-Sleep -Milliseconds 250
+}
+'@
+        $browserWorker = $browserWorker.Replace("__PORT__", [string]$ReadyPort).Replace("__URL__", $Url)
+        $encodedCommand = [Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($browserWorker))
+        $shell = Get-Command pwsh -ErrorAction SilentlyContinue
+        if (-not $shell) {
+            $shell = Get-Command powershell -ErrorAction SilentlyContinue
+        }
 
-            $deadline = [DateTime]::UtcNow.AddSeconds(30)
-            while ([DateTime]::UtcNow -lt $deadline) {
-                try {
-                    $client = New-Object System.Net.Sockets.TcpClient
-                    $async = $client.BeginConnect("127.0.0.1", $TargetPort, $null, $null)
-                    if ($async.AsyncWaitHandle.WaitOne(250)) {
-                        $client.EndConnect($async)
-                        $client.Close()
-                        Start-Process $TargetUrl | Out-Null
-                        return
-                    }
-                    $client.Close()
-                }
-                catch {
-                }
-                [System.Threading.Thread]::Sleep(250)
-            }
+        if ($shell) {
+            Start-Process -FilePath $shell.Source -WindowStyle Hidden -ArgumentList @("-NoProfile", "-EncodedCommand", $encodedCommand) | Out-Null
+            return
+        }
 
-            try {
-                Start-Process $TargetUrl | Out-Null
-            }
-            catch {
-            }
-        } -ArgumentList $Url, $ReadyPort | Out-Null
+        throw "No PowerShell host found"
     }
     catch {
         Write-Host "[WARN] Unable to open browser automatically. Please open $Url manually." -ForegroundColor DarkYellow
@@ -131,9 +136,9 @@ $browserUrl = "http://127.0.0.1:$resolvedPort"
 
 switch ($Mode) {
     "companion" {
-        $args = @("aurora_companion.py", "--device", $Device, "--port", $resolvedPort)
+        $launchArgs = @("aurora_companion.py", "--device", $Device, "--port", $resolvedPort)
         if ($Output -ne "") {
-            $args += @("--output", $Output)
+            $launchArgs += @("--output", $Output)
         }
 
         Write-Host "=== Aurora Companion ===" -ForegroundColor Cyan
@@ -146,7 +151,7 @@ switch ($Mode) {
         else {
             Write-Host "Camera device: $Device" -ForegroundColor Yellow
         }
-        Write-Host "Capture pipeline: sensor 1280x720 -> training 640x360" -ForegroundColor Yellow
+        Write-Host "Capture pipeline: actual acquisition 1280x720; optional training crop 640x360" -ForegroundColor Yellow
         $tabCamera = -join ([char[]](0x6444, 0x50CF, 0x5934, 0x91C7, 0x96C6))
         $tabLink = -join ([char[]](0x8054, 0x901A, 0x6D4B, 0x8BD5))
         $tabChassis = -join ([char[]](0x5E95, 0x76D8, 0x901A, 0x4FE1, 0x8C03, 0x8BD5))
@@ -162,11 +167,11 @@ switch ($Mode) {
         }
 
         $hideStderr = -not $ShowDriverLogs
-        Invoke-PythonTool -Python $Python -Arguments $args -SuppressStderr:$hideStderr
+        Invoke-PythonTool -Python $Python -Arguments $launchArgs -SuppressStderr:$hideStderr
         break
     }
     "a1" {
-        $args = @("a1_companion.py", "--port", $resolvedPort)
+        $launchArgs = @("a1_companion.py", "--port", $resolvedPort)
         Write-Host "=== A1 Companion ===" -ForegroundColor Cyan
         Write-Host "Starting A1 Companion (camera + OSD + chassis debug)..." -ForegroundColor Green
         Write-Host "Web UI: $browserUrl" -ForegroundColor Yellow
@@ -179,13 +184,13 @@ switch ($Mode) {
         }
 
         $hideStderr = -not $ShowDriverLogs
-        Invoke-PythonTool -Python $Python -Arguments $args -SuppressStderr:$hideStderr
+        Invoke-PythonTool -Python $Python -Arguments $launchArgs -SuppressStderr:$hideStderr
         break
     }
     "viewer" {
-        $args = @("a1_viewer.py", "--port", $resolvedPort)
+        $launchArgs = @("a1_viewer.py", "--port", $resolvedPort)
         if ($Device -ge 0) {
-            $args += @("--device", $Device)
+            $launchArgs += @("--device", $Device)
         }
 
         Write-Host "=== A1 Viewer ===" -ForegroundColor Cyan
@@ -198,11 +203,11 @@ switch ($Mode) {
             Start-BrowserWhenReady -ReadyPort $resolvedPort -Url $browserUrl
         }
 
-        Invoke-PythonTool -Python $Python -Arguments $args
+        Invoke-PythonTool -Python $Python -Arguments $launchArgs
         break
     }
     "probe" {
-        $args = @("stm32_port_probe.py", "--port", $resolvedPort)
+        $launchArgs = @("stm32_port_probe.py", "--port", $resolvedPort)
         Write-Host "=== STM32 Port Probe ===" -ForegroundColor Cyan
         Write-Host "Starting COM port probe page..." -ForegroundColor Green
         Write-Host "Web UI: $browserUrl" -ForegroundColor Yellow
@@ -213,13 +218,13 @@ switch ($Mode) {
             Start-BrowserWhenReady -ReadyPort $resolvedPort -Url $browserUrl
         }
 
-        Invoke-PythonTool -Python $Python -Arguments $args
+        Invoke-PythonTool -Python $Python -Arguments $launchArgs
         break
     }
     "capture" {
-        $args = @("aurora_capture.py", "--device", $Device, "--port", $resolvedPort)
+        $launchArgs = @("aurora_capture.py", "--device", $Device, "--port", $resolvedPort)
         if ($Output -ne "") {
-            $args += @("--output", $Output)
+            $launchArgs += @("--output", $Output)
         }
 
         Write-Host "=== Aurora Capture ===" -ForegroundColor Cyan
@@ -232,7 +237,7 @@ switch ($Mode) {
             Start-BrowserWhenReady -ReadyPort $resolvedPort -Url $browserUrl
         }
 
-        Invoke-PythonTool -Python $Python -Arguments $args -SuppressStderr
+        Invoke-PythonTool -Python $Python -Arguments $launchArgs -SuppressStderr
         break
     }
 }

--- a/tools/aurora/relay_comm.py
+++ b/tools/aurora/relay_comm.py
@@ -14,7 +14,7 @@ relay_bp = Blueprint("relay", __name__, url_prefix="/api/relay")
 
 _relay_lock = threading.Lock()
 _relay_state: Dict[str, Any] = {
-    "base_url": os.environ.get("A1_COMPANION_URL", "http://127.0.0.1:5803"),
+    "base_url": os.environ.get("A1_COMPANION_URL", "").strip(),
     "timeout_sec": 2.5,
 }
 
@@ -22,7 +22,7 @@ _relay_state: Dict[str, Any] = {
 def _normalize_base_url(value: str) -> str:
     text = (value or "").strip()
     if not text:
-        raise ValueError("A1 Companion 地址不能为空")
+        return ""
     if not text.startswith("http://") and not text.startswith("https://"):
         text = f"http://{text}"
     return text.rstrip("/")
@@ -46,7 +46,11 @@ def _update_state(base_url: Optional[str] = None,
 def _relay_json(method: str, path: str,
                 payload: Optional[Dict[str, Any]] = None) -> Any:
     state = _snapshot_state()
-    target = f"{state['base_url']}{path}"
+    base_url = (state.get("base_url") or "").strip()
+    if not base_url:
+        raise RuntimeError("A1 Companion 地址未配置")
+
+    target = f"{base_url}{path}"
     body = None if payload is None else json.dumps(payload).encode("utf-8")
     headers = {"Content-Type": "application/json"} if body is not None else {}
     req = urllib.request.Request(target, data=body, headers=headers,

--- a/tools/aurora/templates/companion_ui.html
+++ b/tools/aurora/templates/companion_ui.html
@@ -383,7 +383,7 @@ select option{background:var(--surface);}
         </div>
         <div class="preview-wrap">
           <img id="stream" src="/video_feed" alt="camera"
-               onload="onStreamLoad()" onerror="onStreamError()">
+               onload="typeof onStreamLoad === 'function' && onStreamLoad()" onerror="typeof onStreamError === 'function' && onStreamError()">
           <div class="preview-badges">
             <div class="preview-badge" id="streamSourceChip">Windows 纯预览</div>
             <div class="preview-badge secondary" id="streamModeChip">纯图像 · 无框</div>
@@ -726,7 +726,7 @@ select option{background:var(--surface);}
       <div class="card-body">
         <div class="form-row">
           <label>地址</label>
-          <input type="text" id="relayUrl" value="http://127.0.0.1:5803" placeholder="http://A1-IP:5803">
+          <input type="text" id="relayUrl" value="" placeholder="http://A1-IP:5803">
         </div>
         <div class="form-row">
           <label>超时</label>
@@ -1283,7 +1283,9 @@ function refreshCam() {
   });
 }
 
+let _camDeviceRetryTimer = null;
 function loadCameraDevices() {
+  if (_camDeviceRetryTimer) { clearTimeout(_camDeviceRetryTimer); _camDeviceRetryTimer = null; }
   fetch('/camera_devices').then(r=>r.json()).then(d=>{
     const sel = document.getElementById('cameraSelect');
     if (!sel) return;
@@ -1293,6 +1295,12 @@ function loadCameraDevices() {
     if (backendSource) selectedCameraSource = backendSource;
     const current = d.current_device;
     if (!devices.length) {
+      if (d.bootstrapping) {
+        // 后台正在探测摄像头，1 秒后自动重试
+        sel.innerHTML = '<option value="">— 正在探测摄像头… —</option>';
+        _camDeviceRetryTimer = setTimeout(loadCameraDevices, 1000);
+        return;
+      }
       sel.innerHTML = '<option value="">— 无可用摄像头 —</option>';
       selectedCameraSource = 'auto';
       updateSourceHint();
@@ -1308,7 +1316,13 @@ function loadCameraDevices() {
     syncSourceButtons();
     updateSourceHint();
     updateStreamSummary();
-  }).catch(()=>{});
+  }).catch(()=>{
+    // 网络/500 错误时，若仍在探测状态则继续轮询
+    const sel = document.getElementById('cameraSelect');
+    if (sel && sel.options[0] && sel.options[0].text.includes('探测')) {
+      _camDeviceRetryTimer = setTimeout(loadCameraDevices, 1500);
+    }
+  });
 }
 
 function switchCamera() {
@@ -1317,12 +1331,17 @@ function switchCamera() {
   const device = parseInt(sel.value, 10);
   if (Number.isNaN(device)) { toast('设备号无效', 'err'); return; }
 
+  const selectedDevice = cameraDevicesCache.find(cam => cam.id === device);
+  const requestedSource = selectedDevice && selectedDevice.source
+    ? selectedDevice.source
+    : selectedCameraSource;
+
   sel.disabled = true;
   showStreamLoading('切换摄像头中，请稍候…');
   fetch('/switch_camera', {
     method:'POST',
     headers:{'Content-Type':'application/json'},
-    body:JSON.stringify({device, source:selectedCameraSource})
+    body:JSON.stringify({device, source:requestedSource})
   }).then(r=>r.json()).then(d=>{
     if (d.success) {
       const img = document.getElementById('stream');
@@ -1555,6 +1574,11 @@ function saveRelayConfig(showToast = true) {
 }
 
 function loadRelayPorts(markNew = false) {
+  const baseUrl = document.getElementById('relayUrl').value.trim();
+  if (!baseUrl) {
+    document.getElementById('relayPortSelect').innerHTML = '';
+    return Promise.resolve({ports: []});
+  }
   return apiJson('/api/relay/ports').then(d => {
     const ports = normalizePortResponse(d);
     renderRelayPortOptions(ports, markNew);
@@ -1563,6 +1587,19 @@ function loadRelayPorts(markNew = false) {
 }
 
 function loadRelayStatus(silent = true) {
+  const baseUrl = document.getElementById('relayUrl').value.trim();
+  if (!baseUrl) {
+    relayConnected = false;
+    const reach = document.getElementById('relayReachability');
+    reach.textContent = '未配置';
+    reach.style.color = 'var(--muted)';
+    document.getElementById('relayModelName').textContent = '—';
+    document.getElementById('relayConnMsg').textContent = '未配置 A1 Companion 地址';
+    document.getElementById('relayConnectBtn').disabled = true;
+    document.getElementById('relayDisconnectBtn').disabled = true;
+    if (controlTarget === 'relay') setChsStatus(false, null, 'relay');
+    return Promise.resolve({success: false, reachable: false, error: 'A1 Companion 地址未配置'});
+  }
   return apiJson('/api/relay/status').then(d => {
     relayConnected = !!d.connected;
     const reach = document.getElementById('relayReachability');


### PR DESCRIPTION
This PR fixes the A1 camera selection path so the companion UI can discover and select the actual 1280x720 camera instead of getting stuck in an empty/bootstrapping state.

Key changes:
- Tighten camera probing so the A1 source is identified from real content and gray-format support, not from black startup frames.
- Keep the frontend polling while bootstrap discovery is still running, then populate the camera selector once devices are available.
- Align the launch script and companion entrypoints with the updated A1/relay startup behavior.
- Fix a few SDK-side ownership/default-initialization issues in the OSD demo while touching the A1 camera path.

No issue reference was provided.