### PR TITLE
feat: refine Aurora companion camera and chassis workflows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ src/ros2_ws/src/wheeltec_robot_urdf/
 tools/aurora/modules/__pycache__/
 tools/aurora/__pycache__/
 tools/aurora/.a1_camera_device
+tools/aurora/.a1_camera_source
 tools/aurora/.a1_detect_model
 third_party/ultralytics
 models

--- a/data/A1_SDK_SC132GS/smartsens_sdk/smart_software/src/app_demo/face_detection/ssne_ai_demo/demo_face.cpp
+++ b/data/A1_SDK_SC132GS/smartsens_sdk/smart_software/src/app_demo/face_detection/ssne_ai_demo/demo_face.cpp
@@ -145,9 +145,11 @@ int main() {
             bool has_forward = false;
             bool has_stop = false;
             bool has_obstacle = false;
+            bool has_backward = false;
             size_t forward_count = 0;
             size_t stop_count = 0;
             size_t obstacle_count = 0;
+            size_t backward_count = 0;
 
             // 遍历所有检测框进行坐标转换
             for (size_t i = 0; i < det_result->boxes.size(); i++) {
@@ -172,6 +174,9 @@ int main() {
                 } else if (cls_id == cfg::TARGET_CLASS_OBSTACLE_BOX) {
                     has_obstacle = true;
                     obstacle_count++;
+                } else if (cls_id == cfg::TARGET_CLASS_BACKWARD) {
+                    has_backward = true;
+                    backward_count++;
                 }
             }
             
@@ -190,6 +195,10 @@ int main() {
             } else if (has_stop) {
                 printf("[STOP] 检测到 stop 手势 %zu 个，停车\n", stop_count);
                 if (chassis_ok) chassis.SendVelocity(cfg::VX_STOP, 0, 0);
+            } else if (has_backward) {
+                printf("[DRIVE] 检测到 backward 手势 %zu 个，后退 %d mm/s\n",
+                       backward_count, cfg::VX_BACKWARD);
+                if (chassis_ok) chassis.SendVelocity(cfg::VX_BACKWARD, 0, 0);
             } else if (has_forward) {
                 printf("[DRIVE] 检测到 forward 手势 %zu 个，直行 %d mm/s\n",
                        forward_count, cfg::VX_FORWARD);

--- a/data/A1_SDK_SC132GS/smartsens_sdk/smart_software/src/app_demo/face_detection/ssne_ai_demo/project_paths.hpp
+++ b/data/A1_SDK_SC132GS/smartsens_sdk/smart_software/src/app_demo/face_detection/ssne_ai_demo/project_paths.hpp
@@ -42,6 +42,7 @@ constexpr int  TARGET_CLASS_PERSON       = 0;
 constexpr int  TARGET_CLASS_FORWARD      = 1;
 constexpr int  TARGET_CLASS_STOP         = 2;
 constexpr int  TARGET_CLASS_OBSTACLE_BOX = 3;
+constexpr int  TARGET_CLASS_BACKWARD     = 4;
 // DFL 回归 bins 数量
 constexpr int  YOLO_REG_BINS    = 16;
 // YOLOv8 三个 FPN 尺度的步长
@@ -62,6 +63,7 @@ constexpr int   DET_KEEP_TOP_K  = 30;
 // ─── 底盘控制参数 ─────────────────────────────────────────────────────────────
 constexpr uint32_t UART_BAUD   = 115200;  // 波特率
 constexpr int16_t  VX_FORWARD  =  100;   // 前进速度 (mm/s)
+constexpr int16_t  VX_BACKWARD = -100;   // 后退速度 (mm/s)
 constexpr int16_t  VX_STOP     =    0;   // 停止
 
 } // namespace cfg

--- a/tools/aurora/aurora_companion.py
+++ b/tools/aurora/aurora_companion.py
@@ -106,6 +106,7 @@ _last_reconnect_time = 0.0
 
 MAX_DEVICE_SCAN = 5
 PREFERRED_DEVICE_FILE = Path(__file__).with_name(".a1_camera_device")
+PREFERRED_SOURCE_FILE = Path(__file__).with_name(".a1_camera_source")
 CAMERA_SOURCE_WINDOWS = "windows"
 CAMERA_SOURCE_A1 = "a1"
 CAMERA_SOURCE_AUTO = "auto"
@@ -175,6 +176,13 @@ def _open_raw_camera(device_id: int) -> cv2.VideoCapture:
 
 def _source_label(source: str) -> str:
     return SOURCE_LABELS.get(source, source)
+
+
+def _normalize_camera_source(source: Optional[str], fallback: str = CAMERA_SOURCE_AUTO) -> str:
+    normalized = str(source or "").strip().lower()
+    if normalized in {CAMERA_SOURCE_WINDOWS, CAMERA_SOURCE_A1, CAMERA_SOURCE_AUTO}:
+        return normalized
+    return fallback
 
 
 def _infer_device_source(info: dict) -> str:
@@ -256,46 +264,72 @@ def save_preferred_device(device_id: int) -> None:
         pass
 
 
+def load_preferred_source() -> Optional[str]:
+    try:
+        if not PREFERRED_SOURCE_FILE.exists():
+            return None
+        text = PREFERRED_SOURCE_FILE.read_text(encoding="utf-8").strip()
+        if text == "":
+            return None
+        return _normalize_camera_source(text, CAMERA_SOURCE_AUTO)
+    except Exception:
+        return None
+
+
+def save_preferred_source(source: str) -> None:
+    try:
+        PREFERRED_SOURCE_FILE.write_text(
+            _normalize_camera_source(source, CAMERA_SOURCE_AUTO),
+            encoding="utf-8",
+        )
+    except Exception:
+        pass
+
+
 def probe_camera_device(device_id: int) -> dict:
-    cap = _open_raw_camera(device_id)
-    if not cap.isOpened():
-        return {
-            "id": device_id,
-            "opened": False,
-            "score": -1,
-            "actual_width": 0,
-            "actual_height": 0,
-            "is_grayscale": False,
-            "has_content": False,
-            "supports_gray_fourcc": False,
-            "source": CAMERA_SOURCE_WINDOWS,
-            "source_label": _source_label(CAMERA_SOURCE_WINDOWS),
-        }
+    with camera_lock:
+        cap = _open_raw_camera(device_id)
+        if not cap.isOpened():
+            cap.release()
+            return {
+                "id": device_id,
+                "opened": False,
+                "score": -1,
+                "actual_width": 0,
+                "actual_height": 0,
+                "is_grayscale": False,
+                "has_content": False,
+                "supports_gray_fourcc": False,
+                "source": CAMERA_SOURCE_WINDOWS,
+                "source_label": _source_label(CAMERA_SOURCE_WINDOWS),
+            }
 
-    with _suppress_c_stderr():
-        gray_fourccs = [
-            cv2.VideoWriter_fourcc(*"Y800"),
-            cv2.VideoWriter_fourcc(*"GREY"),
-            cv2.VideoWriter_fourcc(*"Y8  "),
-            cv2.VideoWriter_fourcc(*"Y16 "),
-        ]
-        supports_gray_fourcc = False
-        for fourcc in gray_fourccs:
-            cap.set(cv2.CAP_PROP_FOURCC, fourcc)
-            actual = int(cap.get(cv2.CAP_PROP_FOURCC))
-            if actual == fourcc:
-                supports_gray_fourcc = True
-                break
+        try:
+            with _suppress_c_stderr():
+                gray_fourccs = [
+                    cv2.VideoWriter_fourcc(*"Y800"),
+                    cv2.VideoWriter_fourcc(*"GREY"),
+                    cv2.VideoWriter_fourcc(*"Y8  "),
+                    cv2.VideoWriter_fourcc(*"Y16 "),
+                ]
+                supports_gray_fourcc = False
+                for fourcc in gray_fourccs:
+                    cap.set(cv2.CAP_PROP_FOURCC, fourcc)
+                    actual = int(cap.get(cv2.CAP_PROP_FOURCC))
+                    if actual == fourcc:
+                        supports_gray_fourcc = True
+                        break
 
-        cap.set(cv2.CAP_PROP_FRAME_WIDTH, CAMERA_WIDTH)
-        cap.set(cv2.CAP_PROP_FRAME_HEIGHT, CAMERA_HEIGHT)
-        # 丢弃前几帧：DirectShow 管道初始化期间第 1 帧通常为全黑
-        for _ in range(3):
-            cap.read()
-        ret, frame = cap.read()
-        actual_w = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
-        actual_h = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
-        cap.release()
+                cap.set(cv2.CAP_PROP_FRAME_WIDTH, CAMERA_WIDTH)
+                cap.set(cv2.CAP_PROP_FRAME_HEIGHT, CAMERA_HEIGHT)
+                # 丢弃前几帧：DirectShow 管道初始化期间第 1 帧通常为全黑
+                for _ in range(3):
+                    cap.read()
+                ret, frame = cap.read()
+                actual_w = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+                actual_h = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+        finally:
+            cap.release()
 
     if not ret or frame is None:
         source = CAMERA_SOURCE_A1 if supports_gray_fourcc else CAMERA_SOURCE_WINDOWS
@@ -380,12 +414,20 @@ def list_camera_devices(max_scan: int = MAX_DEVICE_SCAN) -> list:
 def choose_camera_device(requested_device: int) -> Tuple[int, list]:
     """返回 (device_id, candidates)。requested_device=-1 时自动优先 A1。"""
     if requested_device >= 0:
-        return requested_device, list_camera_devices()
+        info = probe_camera_device(requested_device)
+        return requested_device, [info] if info["opened"] else []
 
     preferred = load_preferred_device()
+    preferred_source = load_preferred_source()
     if preferred is not None:
         preferred_info = probe_camera_device(preferred)
         if preferred_info["opened"] and (preferred_info.get("has_content") or preferred_info.get("supports_gray_fourcc")):
+            cached_source = _normalize_camera_source(
+                preferred_source,
+                preferred_info.get("source", CAMERA_SOURCE_WINDOWS),
+            )
+            preferred_info["source"] = cached_source
+            preferred_info["source_label"] = _source_label(cached_source)
             return preferred, [preferred_info]
 
     candidates = list_camera_devices()
@@ -457,6 +499,7 @@ def bootstrap_camera(requested_device: int) -> None:
 
         print(f"[INFO] 正在连接摄像头 (设备 {selected_device}, source={camera_source_global})...")
         save_preferred_device(selected_device)
+        save_preferred_source(camera_source_global)
         try:
             opened_camera = open_camera(selected_device, camera_source_global)
         except Exception as e:
@@ -1286,7 +1329,7 @@ def switch_camera():
 
     try:
         if requested_source == CAMERA_SOURCE_AUTO:
-            for info in list_camera_devices():
+            for info in camera_devices_snapshot:
                 if info["id"] == new_device:
                     requested_source = info.get("source", CAMERA_SOURCE_WINDOWS)
                     break
@@ -1306,6 +1349,7 @@ def switch_camera():
         _consecutive_failures = 0
         camera_connected = True
         save_preferred_device(new_device)
+        save_preferred_source(requested_source)
         print(f"[INFO] 已切换到摄像头设备 {new_device} ({requested_source})")
         return jsonify({"success": True, "device": new_device, "source": requested_source})
     except Exception as e:

--- a/tools/aurora/launch.ps1
+++ b/tools/aurora/launch.ps1
@@ -68,24 +68,40 @@ function Start-BrowserWhenReady {
     try {
         $browserWorker = @'
 $deadline = [DateTime]::UtcNow.AddSeconds(180)
+$statusUrl = "__URL__status"
+$baseUrl = "__URL__"
 while ([DateTime]::UtcNow -lt $deadline) {
     try {
+        # Fast TCP check
         $client = New-Object System.Net.Sockets.TcpClient
         $async = $client.BeginConnect("127.0.0.1", __PORT__, $null, $null)
-        if ($async.AsyncWaitHandle.WaitOne(250)) {
+        $tcpOk = $async.AsyncWaitHandle.WaitOne(200)
+        
+        if ($tcpOk) {
             $client.EndConnect($async)
             $client.Close()
-            Start-Process "__URL__" | Out-Null
-            exit 0
+            # HTTP check
+            $response = Invoke-WebRequest -Uri $baseUrl -UseBasicParsing -TimeoutSec 1 -ErrorAction SilentlyContinue
+            if ($response.StatusCode -ge 200) {
+                Start-Process $baseUrl | Out-Null
+                exit 0
+            }
+        } else {
+            $client.Close()
         }
-        $client.Close()
     }
     catch {
     }
-    Start-Sleep -Milliseconds 250
+    Start-Sleep -Milliseconds 500
 }
 '@
         $browserWorker = $browserWorker.Replace("__PORT__", [string]$ReadyPort).Replace("__URL__", $Url)
+        if (-not $browserWorker.Contains("__URL__status")) {
+            # Ensure proper URL formatting
+            if (-not $Url.EndsWith("/")) {
+                $browserWorker = $browserWorker.Replace("__URL__status", "$Url/status")
+            }
+        }
         $encodedCommand = [Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($browserWorker))
         $shell = Get-Command pwsh -ErrorAction SilentlyContinue
         if (-not $shell) {
@@ -112,7 +128,17 @@ function Invoke-PythonTool {
     )
 
     if ($SuppressStderr) {
-        & $Python @Arguments 2>$null
+        $errFile = [System.IO.Path]::GetTempFileName()
+        try {
+            # Route stderr to file
+            $proc = Start-Process -FilePath $Python -ArgumentList $Arguments -NoNewWindow -Wait -RedirectStandardError $errFile -PassThru
+            if ($proc.ExitCode -ne 0) {
+                Write-Host "`n[ERROR] Python script exited with code $($proc.ExitCode). Error output:`n" -ForegroundColor Red
+                Get-Content $errFile | Out-String | Write-Host -ForegroundColor Red
+            }
+        } finally {
+            if (Test-Path $errFile) { Remove-Item $errFile -Force }
+        }
     }
     else {
         & $Python @Arguments
@@ -133,6 +159,26 @@ Write-Host "[INFO] Python: $Python" -ForegroundColor DarkGray
 
 $resolvedPort = if ($Port -gt 0) { $Port } else { Get-DefaultPort -LaunchMode $Mode }
 $browserUrl = "http://127.0.0.1:$resolvedPort"
+
+if (-not $PSBoundParameters.ContainsKey("Mode")) {
+    Write-Host "=== Aurora Launch === " -ForegroundColor Cyan
+    Write-Host "1. Aurora Companion (camera + chassis debug)"
+    Write-Host "2. A1 Companion (OSD + chassis + camera)"
+    Write-Host "3. A1 Viewer (board-side OSD preview)"
+    Write-Host "4. STM32 Port Probe"
+    Write-Host "5. Aurora Capture (image preview + dataset export)"
+    Write-Host ""
+    $choice = Read-Host "Select execution mode [1]"
+    switch ($choice) {
+        "2" { $Mode = "a1" }
+        "3" { $Mode = "viewer" }
+        "4" { $Mode = "probe" }
+        "5" { $Mode = "capture" }
+        default { $Mode = "companion" }
+    }
+    $resolvedPort = if ($Port -gt 0) { $Port } else { Get-DefaultPort -LaunchMode $Mode }
+    $browserUrl = "http://127.0.0.1:$resolvedPort"
+}
 
 switch ($Mode) {
     "companion" {

--- a/tools/aurora/launch.ps1
+++ b/tools/aurora/launch.ps1
@@ -1,4 +1,4 @@
-param(
+﻿param(
     [ValidateSet("companion", "a1", "viewer", "probe", "capture")]
     [string]$Mode = "companion",
     [int]$Device = -1,

--- a/tools/aurora/launch.ps1
+++ b/tools/aurora/launch.ps1
@@ -190,18 +190,20 @@ switch ($Mode) {
         Write-Host "=== Aurora Companion ===" -ForegroundColor Cyan
         Write-Host "Starting Aurora Companion (camera + chassis debug)..." -ForegroundColor Green
         Write-Host "Web UI: $browserUrl" -ForegroundColor Yellow
-        Write-Host "Browser: auto-open enabled (use -NoBrowser to disable)" -ForegroundColor Yellow
+        if ($NoBrowser) {
+            Write-Host "Browser: auto-open disabled" -ForegroundColor Yellow
+        }
+        else {
+            Write-Host "Browser: auto-open enabled (use -NoBrowser to disable)" -ForegroundColor Yellow
+        }
         if ($Device -eq -1) {
-            Write-Host "Camera device: auto (prefer A1 SC132GS)" -ForegroundColor Yellow
+            Write-Host "Camera device: auto (reuse last successful device/source, fallback to scan)" -ForegroundColor Yellow
         }
         else {
             Write-Host "Camera device: $Device" -ForegroundColor Yellow
         }
         Write-Host "Capture pipeline: actual acquisition 1280x720; optional training crop 640x360" -ForegroundColor Yellow
-        $tabCamera = -join ([char[]](0x6444, 0x50CF, 0x5934, 0x91C7, 0x96C6))
-        $tabLink = -join ([char[]](0x8054, 0x901A, 0x6D4B, 0x8BD5))
-        $tabChassis = -join ([char[]](0x5E95, 0x76D8, 0x901A, 0x4FE1, 0x8C03, 0x8BD5))
-        Write-Host "Tabs: $tabCamera / A1-STM32 $tabLink / $tabChassis" -ForegroundColor Yellow
+        Write-Host "UI: 左侧预览工作台 / 电脑直连 / 经由 A1" -ForegroundColor Yellow
         if (-not $ShowDriverLogs) {
             Write-Host "Driver logs: hidden (use -ShowDriverLogs to enable)" -ForegroundColor Yellow
         }

--- a/tools/aurora/ros_bridge.py
+++ b/tools/aurora/ros_bridge.py
@@ -31,6 +31,8 @@ _ROS_CONFIG: Dict[str, Any] = {
     "serial_baud": 115200,
     "forward_linear_x": 0.18,
     "forward_angular_z": 0.0,
+    "backward_linear_x": -0.18,
+    "backward_angular_z": 0.0,
     "idle_stop_delay_sec": 1.0,
     "trigger_cooldown_sec": 0.8,
     "camera_hfov_deg": 60.0,
@@ -38,6 +40,7 @@ _ROS_CONFIG: Dict[str, Any] = {
     "obstacle_clear_distance": 100.0,
     "automation_enabled": False,
     "forward_enabled": True,
+    "backward_enabled": True,
     "stop_enabled": True,
     "obstacle_enabled": True,
     "last_action": "idle",
@@ -48,12 +51,15 @@ _ROS_CONFIG: Dict[str, Any] = {
 _BOOL_FIELDS = {
     "automation_enabled",
     "forward_enabled",
+    "backward_enabled",
     "stop_enabled",
     "obstacle_enabled",
 }
 _FLOAT_FIELDS = {
     "forward_linear_x",
     "forward_angular_z",
+    "backward_linear_x",
+    "backward_angular_z",
     "idle_stop_delay_sec",
     "trigger_cooldown_sec",
     "camera_hfov_deg",
@@ -355,6 +361,16 @@ def _dispatch_forward(config: Dict[str, Any], reason: str) -> Tuple[bool, str]:
     return ok, message
 
 
+def _dispatch_backward(config: Dict[str, Any], reason: str) -> Tuple[bool, str]:
+    topic = "/cmd_vel_ori" if _process_running("multi_avoidance") else "/cmd_vel"
+    if _process_running("multi_avoidance"):
+        _publish_clear_obstacle()
+    ok, message = _publish_twist(topic, config["backward_linear_x"], config["backward_angular_z"])
+    if ok:
+        _set_last_action("backward", reason)
+    return ok, message
+
+
 def _dispatch_obstacle(config: Dict[str, Any],
                        box: Tuple[float, float, float, float, float, int],
                        frame_shape: Tuple[int, int]) -> Tuple[bool, str]:
@@ -389,12 +405,15 @@ def handle_yolo_detections(detections: Iterable[Tuple[float, float, float, float
     has_stop = bool(config["stop_enabled"] and buckets.get(2))
     obstacle_box = _largest_box(buckets.get(3, [])) if config["obstacle_enabled"] else None
     has_forward = bool(config["forward_enabled"] and buckets.get(1))
+    has_backward = bool(config["backward_enabled"] and buckets.get(4))
 
     action = "idle"
     if has_stop:
         action = "stop"
     elif obstacle_box is not None:
         action = "obstacle"
+    elif has_backward:
+        action = "backward"
     elif has_forward:
         action = "forward"
 
@@ -411,15 +430,17 @@ def handle_yolo_detections(detections: Iterable[Tuple[float, float, float, float
         ok, message = _dispatch_stop("检测到 stop 手势")
     elif action == "obstacle":
         ok, message = _dispatch_obstacle(config, obstacle_box, frame_shape)
+    elif action == "backward":
+        ok, message = _dispatch_backward(config, "检测到 backward 手势")
     elif action == "forward":
         ok, message = _dispatch_forward(config, "检测到 forward 手势")
     else:
-        should_idle_stop = last_action in {"forward", "obstacle"} and (now - last_dispatch_ts) >= float(config["idle_stop_delay_sec"])
+        should_idle_stop = last_action in {"forward", "backward", "obstacle"} and (now - last_dispatch_ts) >= float(config["idle_stop_delay_sec"])
         if should_idle_stop:
             ok, message = _dispatch_stop("手势消失，自动停车")
         else:
             ok, message = True, config["last_reason"]
-            _set_last_action("idle", "等待 forward/stop/obstacle_box")
+            _set_last_action("idle", "等待 forward/backward/stop/obstacle_box")
 
     result["reason"] = message
     result["dispatched"] = ok

--- a/tools/aurora/templates/companion_ui.html
+++ b/tools/aurora/templates/companion_ui.html
@@ -47,14 +47,20 @@
   --shadow-1: 0 1px 3px rgba(0,0,0,0.08);
   --shadow-2: 0 4px 12px rgba(0,0,0,0.1);
 }
+html{
+  height:100%;
+  overflow:hidden;
+}
 *{margin:0;padding:0;box-sizing:border-box;}
 body{
   background: var(--color-bg);
   color: var(--color-primary);
   font-family: 'Noto Sans SC', 'Segoe UI', sans-serif;
+  height:100%;
   min-height: 100vh;
   display: flex;
   flex-direction: column;
+  overflow: hidden;
   font-size: var(--text-sm);
   font-weight: 400;
   line-height: 1.5;
@@ -70,7 +76,6 @@ body{
   height: var(--space-12);
 }
 .logo{display:flex;align-items:center;gap:var(--space-2);padding-right:var(--space-4);border-right:1px solid var(--color-border);}
-.logo-icon{width:var(--space-6);height:var(--space-6);border-radius:var(--radius);background:var(--color-brand);color:white;display:flex;align-items:center;justify-content:center;font-size:var(--text-sm);}
 .logo-text{font-size:var(--text-base);font-family:'Space Grotesk','Noto Sans SC',sans-serif;font-weight:700;color:var(--color-primary);letter-spacing:0;}
 /* Tabs */
 .tabs{display:flex;align-items:center;gap:0;flex:1;padding-left:var(--space-1);}
@@ -93,8 +98,175 @@ body{
 .chassis-dot.off{background:var(--color-error);}
 
 /* ── Tab pages ────────────────────────────────────── */
-.page{display:none;flex:1;}
-.page.active{display:flex;flex-direction:column;}
+.page{display:none;min-height:0;}
+.page.active{display:flex;flex-direction:column;gap:var(--space-3);min-height:0;}
+
+.app-shell{
+  flex:1 1 auto;
+  min-height:0;
+  display:flex;
+  gap:var(--space-3);
+  padding:var(--space-3);
+  overflow:hidden;
+}
+
+.camera-rail{
+  flex:0 0 400px;
+  max-width:400px;
+  min-height:0;
+  overflow-y:auto;
+  overscroll-behavior:contain;
+  display:flex;
+  flex-direction:column;
+  gap:var(--space-2);
+  padding-right:4px;
+}
+
+.page-stage{
+  flex:1 1 0;
+  min-width:0;
+  min-height:0;
+  overflow-y:auto;
+  overscroll-behavior:contain;
+  display:flex;
+  flex-direction:column;
+  gap:var(--space-3);
+  padding-right:4px;
+}
+
+.page-stage > .page.active{
+  flex:0 0 auto;
+}
+
+.workflow-hero{
+  background:linear-gradient(135deg, rgba(37,99,235,0.08), rgba(17,24,39,0.04));
+  border:1px solid var(--color-border);
+  border-radius:var(--radius);
+  padding:var(--space-4);
+  display:flex;
+  flex-direction:column;
+  gap:var(--space-3);
+}
+
+.workflow-eyebrow{
+  font-size:var(--text-xs);
+  color:var(--color-brand);
+  font-weight:700;
+  letter-spacing:.08em;
+  text-transform:uppercase;
+}
+
+.workflow-hero h2{
+  font-family:'Space Grotesk','Noto Sans SC',sans-serif;
+  font-size:var(--text-xl);
+  line-height:1.15;
+  color:var(--color-primary);
+}
+
+.workflow-hero p{
+  color:var(--color-secondary);
+  max-width:780px;
+}
+
+.workflow-points{
+  display:grid;
+  grid-template-columns:repeat(3, minmax(0, 1fr));
+  gap:var(--space-2);
+}
+
+.workflow-point{
+  background:rgba(255,255,255,0.75);
+  border:1px solid var(--color-border);
+  border-radius:var(--radius);
+  padding:var(--space-3);
+  display:flex;
+  flex-direction:column;
+  gap:4px;
+}
+
+.workflow-point strong{color:var(--color-primary);}
+.workflow-point span{color:var(--color-secondary);font-size:var(--text-xs);line-height:1.55;}
+
+.workflow-grid{
+  display:grid;
+  grid-template-columns:repeat(2, minmax(320px, 1fr));
+  gap:var(--space-3);
+  align-items:start;
+  grid-auto-flow:row dense;
+}
+
+.workflow-grid-stm32{
+  grid-template-columns:minmax(300px, 1fr) minmax(360px, 1.08fr);
+  grid-template-areas:
+    "serial ros"
+    "check ros";
+}
+
+.workflow-grid-stm32 .chs-conn{grid-area:serial;}
+.workflow-grid-stm32 .stm32-precheck{grid-area:check;}
+.workflow-grid-stm32 .chs-ros{grid-area:ros;}
+
+.span-all{grid-column:1 / -1;}
+
+.shared-section{
+  display:flex;
+  flex-direction:column;
+  gap:var(--space-3);
+}
+
+.shared-banner{
+  background:var(--color-surface);
+  border:1px solid var(--color-border);
+  border-radius:var(--radius);
+  padding:var(--space-3);
+  display:flex;
+  align-items:flex-start;
+  justify-content:space-between;
+  gap:var(--space-3);
+}
+
+.shared-banner h3{
+  font-size:var(--text-base);
+  color:var(--color-primary);
+  margin:2px 0 6px;
+}
+
+.shared-banner p{
+  color:var(--color-secondary);
+  font-size:var(--text-sm);
+}
+
+.segmented-switch{
+  display:inline-flex;
+  align-items:center;
+  gap:var(--space-1);
+  padding:var(--space-1);
+  background:var(--color-surface-hover);
+  border:1px solid var(--color-border);
+  border-radius:999px;
+}
+
+.segmented-btn{
+  border:none;
+  background:transparent;
+  color:var(--color-secondary);
+  border-radius:999px;
+  padding:6px var(--space-3);
+  font-size:var(--text-xs);
+  font-weight:600;
+  cursor:pointer;
+  transition:all .12s ease;
+}
+
+.segmented-btn:hover{
+  color:var(--color-primary);
+}
+
+.segmented-btn.active{
+  background:var(--color-surface);
+  color:var(--color-brand);
+  box-shadow:var(--shadow-1);
+}
 
 /* ── Cards ────────────────────────────────────────── */
 .card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius);overflow:hidden;}
@@ -107,13 +279,8 @@ body{
 }
 .card-body{padding:var(--space-3);}
 
-/* ── Camera page layout ───────────────────────────── */
-#page-camera .workspace{
-  display:grid;grid-template-columns:1fr 300px;gap:var(--space-3);padding:var(--space-3);flex:1;
-}
 .preview-wrap{position:relative;background:#000;line-height:0;}
 .preview-wrap img{width:100%;display:block;}
-.preview-chip{position:absolute;top:var(--space-2);left:var(--space-2);background:rgba(255,255,255,0.9);border:1px solid var(--color-border);border-radius:var(--radius);padding:var(--space-1) var(--space-2);font-size:var(--text-xs);font-family:monospace;color:var(--color-success);}
 .preview-fps{position:absolute;top:var(--space-2);right:var(--space-2);background:rgba(255,255,255,0.9);border:1px solid var(--color-border);border-radius:var(--radius);padding:var(--space-1) var(--space-2);font-size:var(--text-xs);font-family:monospace;color:var(--color-secondary);}
 
 /* 摄像头加载遮罩 */
@@ -170,7 +337,6 @@ body{
 .det-panel td:first-child{color:var(--color-secondary);width:80px;}
 .det-badge{display:inline-block;background:var(--color-surface-hover);border:1px solid var(--color-border);color:var(--color-primary);border-radius:var(--radius);padding:1px 6px;font-family:monospace;font-size:var(--text-xs);}
 .det-warn{margin-top:var(--space-2);color:var(--color-error);font-size:var(--text-xs);}
-.sidebar{display:flex;flex-direction:column;gap:var(--space-2);}
 .counter-box{text-align:center;padding:var(--space-4) 0 var(--space-2);}
 .counter-num{font-size:var(--text-2xl);font-weight:600;line-height:1.25;color:var(--color-primary);}
 .counter-lbl{font-size:var(--text-xs);color:var(--color-secondary);margin-top:var(--space-1);}
@@ -182,24 +348,6 @@ body{
 .gallery-item img{width:100%;display:block;}
 .gallery-item .g-lbl{position:absolute;bottom:0;left:0;right:0;background:rgba(255,255,255,.9);font-size:var(--text-xs);color:var(--color-secondary);padding:2px var(--space-1);text-align:center;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
 .gallery-empty{grid-column:1/-1;text-align:center;color:var(--color-secondary);font-size:var(--text-sm);padding:var(--space-3) 0;}
-
-/* ── Chassis page layout ──────────────────────────── */
-#page-chassis .workspace{
-  display:grid;
-  grid-template-columns:300px 1fr 1fr;
-  grid-template-rows:auto auto auto auto;
-  gap:var(--space-3);padding:var(--space-3);align-items:start;
-}
-/* column spans */
-.chs-conn  { grid-column:1; grid-row:1; }
-.chs-tele  { grid-column:1; grid-row:2 / span 2; }
-.chs-wiring{ grid-column:2; grid-row:1; }
-.chs-relay { grid-column:3; grid-row:1; }
-.chs-motion{ grid-column:2; grid-row:2; }
-.chs-ros   { grid-column:3; grid-row:2; }
-.chs-rawsend{ grid-column:2; grid-row:3; }
-.chs-debug { grid-column:3; grid-row:3; }
-.chs-log   { grid-column:1 / span 3; grid-row:4; }
 
 /* ── Buttons ──────────────────────────────────────── */
 .btn{
@@ -282,7 +430,6 @@ select:focus, input:focus{outline:none;border-color:var(--color-brand);box-shado
 .speed-row label{font-size:var(--text-sm);color:var(--color-secondary);width:70px;flex-shrink:0;}
 .speed-row input[type=range]{flex:1;accent-color:var(--color-brand);}
 .speed-row .speed-val{font-size:var(--text-sm);font-family:monospace;color:var(--color-primary);width:60px;text-align:right;}
-.target-switch{display:flex;gap:var(--space-1);flex-wrap:wrap;margin-bottom:var(--space-2);}
 
 /* ── Debug logs ───────────────────────────────────── */
 .log-area{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius);padding:var(--space-2) var(--space-2);font-size:var(--text-xs);font-family:monospace;max-height:180px;overflow-y:auto;line-height:1.5;}
@@ -326,9 +473,6 @@ select:focus, input:focus{outline:none;border-color:var(--color-brand);box-shado
 .proto-frame{display:flex;flex-wrap:wrap;gap:var(--space-1);margin-top:var(--space-1);}
 .proto-byte{display:inline-block;text-align:center;min-width:28px;padding:var(--space-1) var(--space-1);border-radius:var(--radius);font-size:var(--text-xs);font-family:monospace;line-height:1.5;background:var(--color-surface-hover);border:1px solid var(--color-border);}
 .proto-byte .addr{color:var(--color-secondary);font-size:var(--text-xs);display:block;}
-
-/* ── STM32 Connectivity page ───────────────────────── */
-#page-stm32 .workspace{display:grid;grid-template-columns:1.1fr .9fr;gap:var(--space-3);padding:var(--space-3);flex:1;align-items:start;}
 .stm32-hero{padding:var(--space-4) var(--space-4);background:var(--color-surface);border-bottom:1px solid var(--color-border);}
 .stm32-hero h2{font-family:'Space Grotesk','Noto Sans SC',sans-serif;font-size:var(--text-lg);letter-spacing:0;margin-bottom:var(--space-2);font-weight:600;color:var(--color-primary);}
 .stm32-hero p{font-size:var(--text-sm);color:var(--color-secondary);line-height:1.5;}
@@ -337,10 +481,18 @@ select:focus, input:focus{outline:none;border-color:var(--color-brand);box-shado
 .stm32-step b{color:var(--color-primary);}
 
 @media (max-width: 1180px){
-  #page-camera .workspace{grid-template-columns:1fr;}
-  #page-stm32 .workspace{grid-template-columns:1fr;}
-  #page-chassis .workspace{grid-template-columns:1fr;grid-template-rows:auto;}
-  .chs-conn,.chs-tele,.chs-wiring,.chs-relay,.chs-motion,.chs-ros,.chs-debug,.chs-rawsend,.chs-log{grid-column:1;grid-row:auto;}
+  .workflow-grid,.workflow-points{grid-template-columns:1fr;}
+  .workflow-grid-stm32{grid-template-areas:
+    "serial"
+    "check"
+    "ros";
+  }
+}
+
+@media (max-width: 900px){
+  .app-shell{flex-direction:column;overflow:auto;}
+  .camera-rail,.page-stage{max-width:none;overflow:visible;padding-right:0;}
+  .camera-rail{flex-basis:auto;}
 }
 
 @media (max-width: 820px){
@@ -349,6 +501,9 @@ select:focus, input:focus{outline:none;border-color:var(--color-brand);box-shado
   .tabs{order:3;flex:1 0 100%;padding-left:0;overflow-x:auto;}
   .tab-btn{height:42px;white-space:nowrap;padding:0 var(--space-3);}
   .topbar-right{margin-left:0;width:100%;justify-content:flex-end;}
+  .app-shell{padding:var(--space-2);}
+  .shared-banner{flex-direction:column;}
+  .chs-log .card-body{grid-template-columns:1fr !important;}
 }
 </style>
 </head>
@@ -357,18 +512,14 @@ select:focus, input:focus{outline:none;border-color:var(--color-brand);box-shado
 <!-- ═══ Topbar ══════════════════════════════════════════════════════════════ -->
 <div class="topbar">
   <div class="logo">
-    <div class="logo-icon">⚡</div>
     <span class="logo-text">Aurora Companion</span>
   </div>
   <div class="tabs">
-    <button class="tab-btn active" onclick="switchTab('camera')" id="tab-camera">
-      📷 摄像头采集
-    </button>
-    <button class="tab-btn" onclick="switchTab('stm32')" id="tab-stm32">
-      🔗 电脑直连
+    <button class="tab-btn active" onclick="switchTab('stm32')" id="tab-stm32">
+      电脑直连
     </button>
     <button class="tab-btn" onclick="switchTab('chassis')" id="tab-chassis">
-      🤖 经由 A1
+      经由 A1
     </button>
   </div>
   <div class="topbar-right">
@@ -383,583 +534,586 @@ select:focus, input:focus{outline:none;border-color:var(--color-brand);box-shado
   </div>
 </div>
 
-<!-- ═══ Camera Page ══════════════════════════════════════════════════════════ -->
-<div class="page active" id="page-camera">
-  <div class="workspace">
-
-    <!-- Preview -->
-    <div style="display:flex;flex-direction:column;gap:10px;">
-      <div class="card">
-        <div class="card-head">
-          <span>实时预览</span>
-          <div style="display:flex;align-items:center;gap:8px;">
-            <button class="stream-tab active" id="tab-stream-preview" onclick="switchStreamTab('preview')">📡 预览</button>
-            <button class="stream-tab" id="tab-stream-detect" onclick="switchStreamTab('detect')">🔍 YOLOv8</button>
-            <span id="streamResLabel" style="color:var(--green);font-size:.9em">Windows 纯预览 · 1280 × 720</span>
-          </div>
-        </div>
-        <div class="preview-wrap">
-          <img id="stream" src="/video_feed" alt="camera"
-               onload="typeof onStreamLoad === 'function' && onStreamLoad()" onerror="typeof onStreamError === 'function' && onStreamError()">
-          <div class="preview-badges">
-            <div class="preview-badge" id="streamSourceChip">Windows 纯预览</div>
-            <div class="preview-badge secondary" id="streamModeChip">纯图像 · 无框</div>
-          </div>
-          <div class="preview-fps" id="fpsChip">— fps</div>
-          <div class="stream-loading" id="streamLoading">
-            <div class="spin-ring"></div>
-            <span id="streamLoadingMsg">摄像头初始化中…</span>
-          </div>
+<div class="app-shell">
+  <aside class="camera-rail">
+    <div class="card">
+      <div class="card-head">
+        <span>实时预览</span>
+        <div style="display:flex;align-items:center;gap:8px;">
+          <button class="stream-tab active" id="tab-stream-preview" onclick="switchStreamTab('preview')">预览</button>
+          <button class="stream-tab" id="tab-stream-detect" onclick="switchStreamTab('detect')">YOLOv8</button>
+          <span id="streamResLabel" style="color:var(--color-success);font-size:.9em">Windows 纯预览 · 1280 × 720</span>
         </div>
       </div>
-
-      <!-- YOLOv8 检测信息面板（仅检测模式显示） -->
-      <div class="card" id="detInfoPanel" style="display:none;">
-        <div class="card-head">YOLOv8 检测信息</div>
-        <div class="det-panel">
-          <table>
-            <tr><td>模型</td><td><span class="det-badge" id="detModelName">best_a1_formal.onnx</span></td></tr>
-            <tr><td>格式</td><td id="detModelMode">标准输出</td></tr>
-            <tr><td>输入尺寸</td><td>640 × 640 (letterbox)</td></tr>
-            <tr><td>类别数</td><td id="detNumCls">4</td></tr>
-            <tr><td>置信度</td><td id="detConf">≥ 0.40</td></tr>
-            <tr><td>NMS IoU</td><td>0.45</td></tr>
-            <tr><td>运行时</td><td id="detRuntime">—</td></tr>
-          </table>
-          <div id="detWarn" class="det-warn" style="display:none;"></div>
+      <div class="preview-wrap">
+        <img id="stream" src="/video_feed" alt="camera"
+             onload="typeof onStreamLoad === 'function' && onStreamLoad()" onerror="typeof onStreamError === 'function' && onStreamError()">
+        <div class="preview-badges">
+          <div class="preview-badge" id="streamSourceChip">Windows 纯预览</div>
+          <div class="preview-badge secondary" id="streamModeChip">纯图像 · 无框</div>
         </div>
-      </div>
-
-      <!-- Gallery -->
-      <div class="card">
-        <div class="card-head">
-          <span>最近拍摄</span>
-          <span id="galleryCount" style="color:var(--muted)">0 / 8</span>
-        </div>
-        <div class="card-body">
-          <div class="gallery-grid" id="gallery">
-            <div class="gallery-empty">暂无拍摄记录</div>
-          </div>
+        <div class="preview-fps" id="fpsChip">— fps</div>
+        <div class="stream-loading" id="streamLoading">
+          <div class="spin-ring"></div>
+          <span id="streamLoadingMsg">摄像头初始化中…</span>
         </div>
       </div>
     </div>
 
-    <!-- Sidebar -->
-    <div class="sidebar">
-      <div class="card">
-        <div class="card-head">拍照控制</div>
-        <div class="card-body">
-          <div class="counter-box">
-            <div class="counter-num" id="counter">0</div>
-            <div class="counter-lbl">已拍摄张数</div>
+    <div class="card" id="detInfoPanel" style="display:none;">
+      <div class="card-head">YOLOv8 检测信息</div>
+      <div class="det-panel">
+        <table>
+          <tr><td>模型</td><td><span class="det-badge" id="detModelName">best_a1_formal.onnx</span></td></tr>
+          <tr><td>格式</td><td id="detModelMode">标准输出</td></tr>
+          <tr><td>输入尺寸</td><td>640 × 640 (letterbox)</td></tr>
+          <tr><td>类别数</td><td id="detNumCls">4</td></tr>
+          <tr><td>置信度</td><td id="detConf">≥ 0.40</td></tr>
+          <tr><td>NMS IoU</td><td>0.45</td></tr>
+          <tr><td>运行时</td><td id="detRuntime">—</td></tr>
+        </table>
+        <div id="detWarn" class="det-warn" style="display:none;"></div>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-head">输入源与采集</div>
+      <div class="card-body">
+        <div class="counter-box">
+          <div class="counter-num" id="counter">0</div>
+          <div class="counter-lbl">已拍摄张数</div>
+        </div>
+        <button class="btn btn-blue btn-full" onclick="capture('1280x720')" style="margin-bottom:5px;">
+          <span class="btn-icon">📷</span>
+          <label>拍照 1280×720<small>当前源的原始画面</small></label>
+        </button>
+        <button class="btn btn-green btn-full" onclick="capture('640x360')">
+          <span class="btn-icon">🏹</span>
+          <label>拍照 640×360<small>YOLOv8 训练集 · 16:9 中心裁剪</small></label>
+        </button>
+        <div class="divider"></div>
+        <button class="btn btn-ghost btn-full" id="camRefreshBtn" onclick="refreshCam()">
+          <span class="btn-icon" id="camRefIcon">刷新</span>
+          <label>刷新摄像头<small>断联后点此恢复</small></label>
+        </button>
+        <div class="divider"></div>
+        <div style="font-size:.72em;color:var(--color-secondary);margin-bottom:6px;">摄像头源</div>
+        <div class="source-switch" id="cameraSourceSwitch">
+          <button class="source-chip active" type="button" data-source="windows" onclick="setCameraSource('windows')">Windows 纯预览</button>
+          <button class="source-chip" type="button" data-source="a1" onclick="setCameraSource('a1')">A1 板端 OSD</button>
+          <button class="source-chip" type="button" data-source="auto" onclick="setCameraSource('auto')">自动识别</button>
+        </div>
+        <div id="cameraSourceHint" class="source-desc">当前将优先选择 <b>Windows 纯预览</b>，预览保持原图不叠加框；YOLOv8 仅在本地 Windows 侧运行。</div>
+        <div style="font-size:.72em;color:var(--color-secondary);margin-top:10px;margin-bottom:6px;">模型（支持 .onnx / .pt）</div>
+        <div class="form-row" style="margin-bottom:6px;">
+          <label>模型</label>
+          <div style="flex:1;display:flex;flex-direction:column;gap:4px;">
+            <input type="text" id="modelSelect" list="modelOptions" placeholder="best_a1_formal.onnx / best.pt">
+            <datalist id="modelOptions"></datalist>
           </div>
-          <button class="btn btn-blue btn-full" onclick="capture('1280x720')" style="margin-bottom:5px;">
-            <span class="btn-icon">📷</span>
-            <label>拍照 1280×720<small>当前源的原始画面</small></label>
-          </button>
-          <button class="btn btn-green btn-full" onclick="capture('640x360')">
-            <span class="btn-icon">🏹</span>
-            <label>拍照 640×360<small>YOLOv8 训练集 · 16:9 中心裁剪</small></label>
-          </button>
-          <div class="divider"></div>
-          <button class="btn btn-ghost btn-full" id="camRefreshBtn" onclick="refreshCam()">
-            <span class="btn-icon" id="camRefIcon">🔄</span>
-            <label>刷新摄像头<small>断联后点此恢复</small></label>
-          </button>
-          <div class="divider"></div>
-          <div style="font-size:.72em;color:var(--muted);margin-bottom:6px;">摄像头源</div>
-          <div class="source-switch" id="cameraSourceSwitch">
-            <button class="source-chip active" type="button" data-source="windows" onclick="setCameraSource('windows')">Windows 纯预览</button>
-            <button class="source-chip" type="button" data-source="a1" onclick="setCameraSource('a1')">A1 板端 OSD</button>
-            <button class="source-chip" type="button" data-source="auto" onclick="setCameraSource('auto')">自动识别</button>
+        </div>
+        <div style="display:flex;gap:8px;">
+          <button class="btn btn-ghost" style="flex:1;justify-content:center;" onclick="loadDetectModels()">列表</button>
+          <button class="btn btn-blue" style="flex:1;justify-content:center;" onclick="switchDetectModel()">切换</button>
+        </div>
+        <div id="modelHint" class="source-desc" style="margin-top:6px;">可以直接输入原始文件名或完整路径，切换后会立即影响 Windows 侧 YOLOv8 检测流。</div>
+        <div class="form-row" style="margin-bottom:6px;">
+          <label>设备</label>
+          <select id="cameraSelect">
+            <option value="">加载中...</option>
+          </select>
+        </div>
+        <div style="display:flex;gap:8px;">
+          <button class="btn btn-ghost" style="flex:1;justify-content:center;" onclick="loadCameraDevices()">列表</button>
+          <button class="btn btn-blue" style="flex:1;justify-content:center;" onclick="switchCamera()">切换</button>
+        </div>
+        <div style="font-size:.72em;color:var(--color-secondary);margin-top:8px;line-height:1.5;">左侧预览在两个工作流页面中保持可见，避免重复打开多路视频流。</div>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-head">
+        <span>最近拍摄</span>
+        <span id="galleryCount" style="color:var(--color-secondary)">0 / 8</span>
+      </div>
+      <div class="card-body">
+        <div class="gallery-grid" id="gallery">
+          <div class="gallery-empty">暂无拍摄记录</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-head">设备信息</div>
+      <div class="card-body">
+        <table class="info-tbl">
+          <tr><td>输入源</td><td>Windows 纯预览 / A1 板端 OSD</td></tr>
+          <tr><td>预览分辨率</td><td>1280 × 720</td></tr>
+          <tr><td>推理输入</td><td>640 × 360 (缩放后)</td></tr>
+          <tr><td>训练裁剪</td><td>640 × 360 (16:9)</td></tr>
+          <tr><td>输出格式</td><td>PNG / JPEG</td></tr>
+          <tr><td>输出目录</td><td>{{ output_dir }}</td></tr>
+        </table>
+        <div class="hint-row">
+          <kbd class="kbd">1</kbd><span>→ 1280×720</span>
+          &nbsp;<kbd class="kbd">2</kbd><span>→ 640×360</span>
+          &nbsp;<kbd class="kbd">R</kbd><span>→ 刷新</span>
+        </div>
+      </div>
+    </div>
+  </aside>
+
+  <main class="page-stage">
+    <div class="page active" id="page-stm32">
+      <section class="workflow-hero">
+        <div class="workflow-eyebrow">电脑直连工作流</div>
+        <h2>电脑直连 STM32</h2>
+        <p>这一页只处理本机串口直连、链路验证与 ROS 直连调试。视频预览、模型切换和采集始终固定在左侧，不需要来回切页找入口。</p>
+        <div class="workflow-points">
+          <div class="workflow-point">
+            <strong>1. 连接串口</strong>
+            <span>选择本地 USB 串口并建立直连，默认波特率 115200。</span>
           </div>
-          <div id="cameraSourceHint" class="source-desc">当前将优先选择 <b>Windows 纯预览</b>，预览保持原图不叠加框；YOLOv8 仅在本地 Windows 侧运行。</div>
-          <div style="font-size:.72em;color:var(--muted);margin-top:10px;margin-bottom:6px;">模型（支持 .onnx / .pt）</div>
-          <div class="form-row" style="margin-bottom:6px;">
-            <label>模型</label>
-            <div style="flex:1;display:flex;flex-direction:column;gap:4px;">
-              <input type="text" id="modelSelect" list="modelOptions" placeholder="best_a1_formal.onnx / best.pt">
-              <datalist id="modelOptions"></datalist>
+          <div class="workflow-point">
+            <strong>2. 验证链路</strong>
+            <span>在下方共享操作区执行联通测试，确认控制下发和遥测回传都正常。</span>
+          </div>
+          <div class="workflow-point">
+            <strong>3. 进入联调</strong>
+            <span>确认遥测正常后，再使用运动控制、原始帧发送或 ROS 节点联调。</span>
+          </div>
+        </div>
+      </section>
+
+      <div class="workflow-grid workflow-grid-stm32">
+        <div class="card chs-conn">
+          <div class="card-head">串口连接与协议</div>
+          <div class="card-body">
+            <div class="form-row">
+              <label>端口</label>
+              <select id="portSelect"></select>
+              <button class="btn btn-ghost" style="padding:5px 10px;" onclick="refreshPorts()" title="刷新端口">⟳</button>
+            </div>
+            <div style="display:flex;gap:8px;margin-top:6px;">
+              <button class="btn btn-ghost" style="flex:1;justify-content:center;" onclick="refreshPorts()">刷新列表</button>
+              <button class="btn btn-blue" style="flex:1;justify-content:center;" onclick="scanNewPorts()">扫描新串口</button>
+            </div>
+            <div class="form-row">
+              <label>波特率</label>
+              <select id="baudSelect">
+                <option value="115200" selected>115200</option>
+                <option value="9600">9600</option>
+                <option value="57600">57600</option>
+                <option value="230400">230400</option>
+              </select>
+            </div>
+            <div style="display:flex;gap:8px;margin-top:6px;">
+              <button class="btn btn-green" id="connectBtn" onclick="connectChassis()" style="flex:1;">连接</button>
+              <button class="btn btn-red" id="disconnectBtn" onclick="disconnectChassis()" style="flex:1;" disabled>断开</button>
+            </div>
+            <div id="chsConnMsg" style="font-size:.75em;color:var(--color-secondary);margin-top:8px;"></div>
+            <div id="portScanHint" style="font-size:.74em;color:var(--color-secondary);margin-top:6px;line-height:1.45;"></div>
+            <div class="divider"></div>
+            <div style="font-size:.75em;color:var(--color-secondary);">
+              <div style="margin-bottom:4px;font-weight:600;color:var(--color-primary);">协议参数</div>
+              <div>帧头: <span style="color:var(--color-error);font-family:monospace;">0x7B</span> &nbsp; 帧尾: <span style="color:var(--color-error);font-family:monospace;">0x7D</span></div>
+              <div style="margin-top:3px;">指令帧: <span style="font-family:monospace;color:var(--color-brand);">11</span> 字节 → STM32</div>
+              <div>遥测帧: <span style="font-family:monospace;color:var(--color-success);">24</span> 字节 ← STM32</div>
+              <div style="margin-top:3px;">校验: <span style="font-family:monospace;color:#7c3aed;">XOR(bytes[0..N-2])</span></div>
+            </div>
+            <div class="divider"></div>
+            <div class="mini-note">如果后续要让 ROS 节点占用同一串口，请先在这里断开直连连接，避免串口竞争。</div>
+          </div>
+        </div>
+
+        <div class="card stm32-precheck">
+          <div class="card-head">直连前检查</div>
+          <div class="card-body">
+            <div class="stm32-steps">
+              <div class="stm32-step"><b>1.</b> 电脑 USB 串口连接 STM32 UART3，并确保共地。</div>
+              <div class="stm32-step"><b>2.</b> 在左侧确认视频源正常，在本页完成串口连接。</div>
+              <div class="stm32-step"><b>3.</b> 到下方共享操作区执行联通测试，发送零速度 11 字节指令帧。</div>
+              <div class="stm32-step"><b>4.</b> 收到 24 字节遥测后，再进行运动控制或 ROS 联调。</div>
+            </div>
+            <div class="divider"></div>
+            <div class="mini-note">联通测试发送帧格式：<span style="font-family:monospace;color:var(--color-primary);">7B 00 00 00 00 00 00 00 00 BCC 7D</span>。若仅显示“单向连通”，通常是 STM32 回传线未接通。</div>
+          </div>
+        </div>
+
+        <div class="card chs-ros">
+          <div class="card-head">ROS 直连调试模块</div>
+          <div class="card-body">
+            <div class="form-row">
+              <label>ROS 串口</label>
+              <input type="text" id="rosPortInput" value="COM7" placeholder="COM7 / /dev/wheeltec_controller">
+              <button class="btn btn-ghost" style="padding:5px 10px;" onclick="useCurrentDirectPortForRos()" title="同步直连串口">同步</button>
+            </div>
+            <div class="form-row">
+              <label>波特率</label>
+              <input type="number" id="rosBaudInput" value="115200" min="9600" step="100">
+            </div>
+            <div style="display:flex;gap:8px;margin-top:6px;">
+              <button class="btn btn-blue" style="flex:1;" onclick="startRosNode('wheeltec_robot_node')">启动底盘节点</button>
+              <button class="btn btn-ghost" style="flex:1;" onclick="stopRosNode('wheeltec_robot_node')">停止</button>
+            </div>
+            <div style="display:flex;gap:8px;margin-top:8px;">
+              <button class="btn btn-amber" style="flex:1;" onclick="startRosNode('multi_avoidance')">启动避障节点</button>
+              <button class="btn btn-ghost" style="flex:1;" onclick="stopRosNode('multi_avoidance')">停止</button>
+            </div>
+            <div class="divider"></div>
+            <div class="form-row" style="align-items:flex-start;">
+              <label style="padding-top:3px;">联动</label>
+              <div style="display:grid;grid-template-columns:1fr;gap:6px;flex:1;font-size:.78em;color:var(--color-secondary);">
+                <label><input type="checkbox" id="rosAutomationEnabled" onchange="applyRosConfig(true)"> 启用 YOLO 快照轮询</label>
+                <label><input type="checkbox" id="rosForwardEnabled" onchange="applyRosConfig(false)" checked> 识别 forward -> ROS 前进</label>
+                <label><input type="checkbox" id="rosBackwardEnabled" onchange="applyRosConfig(false)" checked> 识别 backward -> ROS 后退</label>
+                <label><input type="checkbox" id="rosStopEnabled" onchange="applyRosConfig(false)" checked> 识别 stop -> ROS 停车</label>
+                <label><input type="checkbox" id="rosObstacleEnabled" onchange="applyRosConfig(false)" checked> 识别 obstacle_box -> multi_avoidance</label>
+              </div>
+            </div>
+            <div class="form-row">
+              <label>线速度</label>
+              <input type="number" id="rosForwardLinear" value="0.18" min="0.01" max="1.50" step="0.01">
+            </div>
+            <div class="form-row">
+              <label>视场角</label>
+              <input type="number" id="rosCameraFov" value="60" min="20" max="150" step="1">
+            </div>
+            <div style="display:flex;gap:8px;margin-top:8px;">
+              <button class="btn btn-ghost" style="flex:1;" onclick="loadRosStatus(false)">刷新状态</button>
+              <button class="btn btn-ghost" style="flex:1;" onclick="triggerDetectSnapshot(true)">执行快照</button>
+            </div>
+            <div style="display:flex;gap:8px;margin-top:8px;">
+              <button class="btn btn-blue" style="flex:1;" onclick="testRosForward()">ROS 前进</button>
+              <button class="btn btn-red" style="flex:1;" onclick="stopRosMotion()">ROS 停车</button>
+            </div>
+            <div id="rosStatusMsg" class="mini-note" style="margin-top:8px;">等待 ROS 状态…</div>
+            <div class="divider"></div>
+            <div class="state-line">底盘节点：<b id="rosChassisState">未运行</b></div>
+            <div class="state-line">避障节点：<b id="rosAvoidState">未运行</b></div>
+            <div class="state-line">视觉动作：<b id="rosActionSummary">idle</b></div>
+            <div class="state-line">最近快照：<b id="rosDetectSummary">尚未执行</b></div>
+            <div class="mini-note" style="margin-top:8px;margin-bottom:8px;">左侧预览已经固定显示，切到 A1 板端 OSD 即可观察输入画面。这里复用 src/ros2_ws 中的 wheeltec_robot_node 与 multi_avoidance。</div>
+            <div style="display:grid;grid-template-columns:1fr 1fr;gap:6px;">
+              <div class="mini-note" style="text-align:center;padding:4px;" id="gestureForwardState">前进指令：<b style="color:var(--color-secondary);">未检出</b></div>
+              <div class="mini-note" style="text-align:center;padding:4px;" id="gestureBackwardState">后退指令：<b style="color:var(--color-secondary);">未检出</b></div>
             </div>
           </div>
-          <div style="display:flex;gap:8px;">
-            <button class="btn btn-ghost" style="flex:1;justify-content:center;" onclick="loadDetectModels()">⟳ 列表</button>
-            <button class="btn btn-blue" style="flex:1;justify-content:center;" onclick="switchDetectModel()">🧠 切换</button>
-          </div>
-          <div id="modelHint" class="source-desc" style="margin-top:6px;">可以直接输入原始文件名或完整路径，切换后会立即影响 Windows 侧 YOLOv8 检测流。</div>
-          <div class="form-row" style="margin-bottom:6px;">
-            <label>设备</label>
-            <select id="cameraSelect">
-              <option value="">加载中...</option>
-            </select>
-          </div>
-          <div style="display:flex;gap:8px;">
-            <button class="btn btn-ghost" style="flex:1;justify-content:center;" onclick="loadCameraDevices()">⟳ 列表</button>
-            <button class="btn btn-blue" style="flex:1;justify-content:center;" onclick="switchCamera()">🎥 切换</button>
-          </div>
-          <div style="font-size:.72em;color:var(--muted);margin-top:8px;line-height:1.5;">提示：预览是摄像头原始画面，YOLOv8 切换后会在 Windows 本地叠加检测框。</div>
         </div>
       </div>
+    </div>
 
-      <div class="card">
-        <div class="card-head">设备信息</div>
-        <div class="card-body">
-          <table class="info-tbl">
-            <tr><td>输入源</td><td>Windows 纯预览 / A1 板端 OSD</td></tr>
-            <tr><td>预览分辨率</td><td>1280 × 720</td></tr>
-            <tr><td>推理输入</td><td>640 × 360 (缩放后)</td></tr>
-            <tr><td>训练裁剪</td><td>640 × 360 (16:9)</td></tr>
-            <tr><td>输出格式</td><td>PNG / JPEG</td></tr>
-            <tr><td>输出目录</td><td>{{ output_dir }}</td></tr>
-          </table>
-          <div class="hint-row">
-            <kbd class="kbd">1</kbd><span>→ 1280×720</span>
-            &nbsp;<kbd class="kbd">2</kbd><span>→ 640×360</span>
-            &nbsp;<kbd class="kbd">R</kbd><span>→ 刷新</span>
+    <div class="page" id="page-chassis">
+      <section class="workflow-hero">
+        <div class="workflow-eyebrow">A1 Relay 工作流</div>
+        <h2>经由 A1 到 STM32</h2>
+        <p>这一页聚焦 PC → A1 Relay → STM32 的远端链路。先完成 A1 Companion 地址和远端串口配置，再进入共享操作区执行联通测试与控制。</p>
+        <div class="workflow-points">
+          <div class="workflow-point">
+            <strong>1. 配置 A1 地址</strong>
+            <span>保存 Companion 地址和超时，先确认 A1 Relay 可达。</span>
+          </div>
+          <div class="workflow-point">
+            <strong>2. 连接远端串口</strong>
+            <span>选择 A1 侧实际连接 STM32 的串口与波特率，再建立 relay。</span>
+          </div>
+          <div class="workflow-point">
+            <strong>3. 在共享区控制</strong>
+            <span>联通测试、遥测、运动控制和日志会自动改为 relay 目标。</span>
+          </div>
+        </div>
+      </section>
+
+      <div class="workflow-grid">
+        <div class="card chs-relay">
+          <div class="card-head">A1 Relay 连接</div>
+          <div class="card-body">
+            <div class="form-row">
+              <label>地址</label>
+              <input type="text" id="relayUrl" value="" placeholder="http://A1-IP:5803">
+            </div>
+            <div class="form-row">
+              <label>超时</label>
+              <input type="number" id="relayTimeout" value="2.5" min="0.5" step="0.5">
+            </div>
+            <div style="display:flex;gap:8px;margin-top:6px;">
+              <button class="btn btn-ghost" style="flex:1;justify-content:center;" onclick="saveRelayConfig()">保存地址</button>
+              <button class="btn btn-blue" style="flex:1;justify-content:center;" onclick="loadRelayStatus(false)">检测 Relay</button>
+            </div>
+            <div class="divider"></div>
+            <div class="form-row">
+              <label>远端口</label>
+              <select id="relayPortSelect"></select>
+              <button class="btn btn-ghost" style="padding:5px 10px;" onclick="loadRelayPorts(true)" title="刷新端口">⟳</button>
+            </div>
+            <div class="form-row">
+              <label>波特率</label>
+              <select id="relayBaudSelect">
+                <option value="115200" selected>115200</option>
+                <option value="9600">9600</option>
+                <option value="57600">57600</option>
+                <option value="230400">230400</option>
+              </select>
+            </div>
+            <div style="display:flex;gap:8px;margin-top:6px;">
+              <button class="btn btn-green" id="relayConnectBtn" onclick="connectRelay()" style="flex:1;">连接 Relay</button>
+              <button class="btn btn-red" id="relayDisconnectBtn" onclick="disconnectRelay()" style="flex:1;" disabled>断开</button>
+            </div>
+            <div id="relayConnMsg" style="font-size:.75em;color:var(--color-secondary);margin-top:8px;"></div>
+            <div class="divider"></div>
+            <div class="state-line">Relay 状态：<b id="relayReachability">未检测</b></div>
+            <div class="state-line">远端模型：<b id="relayModelName">—</b></div>
+            <div class="mini-note" style="margin-top:8px;">左侧预览建议切到 A1 板端 OSD，这样可以同时观察远端视觉输入和 relay 链路状态。</div>
+          </div>
+        </div>
+
+        <div class="card">
+          <div class="card-head">经由 A1 的工作顺序</div>
+          <div class="card-body">
+            <div class="stm32-steps">
+              <div class="stm32-step"><b>1.</b> 先保存 A1 Companion 地址，再点击“检测 Relay”确认网络可达。</div>
+              <div class="stm32-step"><b>2.</b> 选择 A1 侧实际接 STM32 的远端串口并建立连接。</div>
+              <div class="stm32-step"><b>3.</b> 到下方共享操作区执行联通测试，验证 PC → A1 → STM32 → A1 → PC 的完整链路。</div>
+              <div class="stm32-step"><b>4.</b> 链路通过后再使用运动控制、原始帧发送和日志面板持续调试。</div>
+            </div>
+          </div>
+        </div>
+
+        <div class="card chs-wiring span-all">
+          <div class="card-head" style="justify-content:space-between;">
+            <span>接线参考</span>
+            <div class="segmented-switch" role="tablist" aria-label="接线参考视图">
+              <button type="button" class="segmented-btn active" data-wiring-view-btn="a1" onclick="setWiringView('a1')" aria-pressed="true">A1 接法</button>
+              <button type="button" class="segmented-btn" data-wiring-view-btn="pc" onclick="setWiringView('pc')" aria-pressed="false">PC 调试接法</button>
+            </div>
+          </div>
+          <div class="card-body">
+            <div id="wiringViewNote" style="font-size:.75em;color:var(--color-secondary);margin-bottom:8px;">A1 Relay 场景下，A1 通过 UART0 与 STM32 UART3 直连并共地。</div>
+            <table class="wire-table">
+              <thead>
+                <tr><th>场景</th><th>发送端 (TX)</th><th>→</th><th>接收端 (RX)</th><th>说明</th></tr>
+              </thead>
+              <tbody>
+                <tr data-wiring-view="a1">
+                  <td><span class="mode-badge badge-ros">A1→STM</span></td>
+                  <td><span class="wire-pin pin-a1">GPIO_PIN_0 (UART0 TX)</span></td>
+                  <td>→</td>
+                  <td><span class="wire-pin pin-stm">PB11 (UART3 RX)</span></td>
+                  <td style="color:var(--color-secondary);font-size:.85em;">A1 控制 STM32</td>
+                </tr>
+                <tr data-wiring-view="a1">
+                  <td><span class="mode-badge badge-ros">STM→A1</span></td>
+                  <td><span class="wire-pin pin-stm">PB10 (UART3 TX)</span></td>
+                  <td>→</td>
+                  <td><span class="wire-pin pin-a1">GPIO_PIN_2 (UART0 RX)</span></td>
+                  <td style="color:var(--color-secondary);font-size:.85em;">遥测回传</td>
+                </tr>
+                <tr data-wiring-view="all">
+                  <td><span class="mode-badge badge-ros">共地</span></td>
+                  <td colspan="2"><span class="wire-pin pin-gnd">A1 GND</span></td>
+                  <td><span class="wire-pin pin-gnd">STM32 GND</span></td>
+                  <td style="color:var(--color-secondary);font-size:.85em;">必须共地</td>
+                </tr>
+                <tr data-wiring-view="pc">
+                  <td><span class="mode-badge badge-pc">PC TX</span></td>
+                  <td><span class="wire-pin pin-pc">USB串口 TX</span></td>
+                  <td>→</td>
+                  <td><span class="wire-pin pin-stm">PB11 (UART3 RX)</span></td>
+                  <td style="color:var(--color-secondary);font-size:.85em;">PC 调试用</td>
+                </tr>
+                <tr data-wiring-view="pc">
+                  <td><span class="mode-badge badge-pc">PC RX</span></td>
+                  <td><span class="wire-pin pin-stm">PB10 (UART3 TX)</span></td>
+                  <td>→</td>
+                  <td><span class="wire-pin pin-pc">USB串口 RX</span></td>
+                  <td style="color:var(--color-secondary);font-size:.85em;">PC 接收遥测</td>
+                </tr>
+              </tbody>
+            </table>
+            <div style="font-size:.72em;color:var(--color-secondary);margin-top:8px;">A1 GPIO UART 为 3.3V TTL 电平；STM32 UART3 同为 3.3V，可直连，<strong style="color:var(--color-warning);">勿接 5V</strong></div>
+            <div class="divider"></div>
+            <div style="font-size:.75em;color:var(--color-secondary);margin-bottom:4px;font-weight:600;">指令帧结构 (11字节: A1→STM32)</div>
+            <div class="proto-frame">
+              <div class="proto-byte hex-header">7B<span class="addr">[0]帧头</span></div>
+              <div class="proto-byte hex-cmd">Cmd<span class="addr">[1]命令</span></div>
+              <div class="proto-byte" style="background:rgba(139,148,158,.1);color:var(--color-secondary)">00<span class="addr">[2]保留</span></div>
+              <div class="proto-byte hex-vel">Vx_H<span class="addr">[3]</span></div>
+              <div class="proto-byte hex-vel">Vx_L<span class="addr">[4]</span></div>
+              <div class="proto-byte hex-vel" style="opacity:.75">Vy_H<span class="addr">[5]</span></div>
+              <div class="proto-byte hex-vel" style="opacity:.75">Vy_L<span class="addr">[6]</span></div>
+              <div class="proto-byte hex-vel" style="opacity:.5">Vz_H<span class="addr">[7]</span></div>
+              <div class="proto-byte hex-vel" style="opacity:.5">Vz_L<span class="addr">[8]</span></div>
+              <div class="proto-byte hex-bcc">BCC<span class="addr">[9]</span></div>
+              <div class="proto-byte hex-tail">7D<span class="addr">[10]帧尾</span></div>
+            </div>
+            <div style="font-size:.72em;color:var(--color-secondary);margin-top:5px;">Cmd: 0x00=运动 · 0x01/0x02=回充 · 0x03=对接 &nbsp;|&nbsp; 速度单位: mm/s (int16 大端)</div>
           </div>
         </div>
       </div>
     </div>
 
-  </div>
-</div>
-
-<!-- ═══ STM32 Connectivity Page ═════════════════════════════════════════════ -->
-<div class="page" id="page-stm32">
-  <div class="workspace">
-    <div class="card">
-      <div class="stm32-hero">
-        <h2>电脑直连 STM32 联通性测试中心</h2>
-        <p>用于快速验证电脑通过 USB 串口直连 STM32 的指令下发链路，以及 STM32 回传遥测链路是否正常。建议先点击“前往直连调试”完成串口连接，再执行联通测试。</p>
-      </div>
-      <div class="card-body">
-        <div style="display:flex;gap:8px;flex-wrap:wrap;margin-bottom:10px;">
-          <button class="btn btn-ghost" onclick="switchTab('chassis'); setControlTarget('direct');">🔧 前往直连调试</button>
-          <button class="btn btn-blue" id="pingBtnPage" onclick="runPingTest('page')">🔍 发起联通测试</button>
-        </div>
-        <pre id="pingResultPage" style="background:var(--surface2);border-radius:8px;padding:10px;font-size:.75em;color:var(--text);font-family:monospace;white-space:pre-wrap;min-height:120px;margin:0;">待执行测试…</pre>
-      </div>
-    </div>
-
-    <div style="display:flex;flex-direction:column;gap:12px;">
-      <div class="card">
-        <div class="card-head">
-          <span>当前链路状态</span>
-          <span id="pingBadgePage" style="font-size:.78em;padding:2px 8px;border-radius:10px;background:var(--surface2);color:var(--muted);">未测试</span>
-        </div>
-        <div class="card-body">
-          <div class="stm32-steps">
-              <div class="stm32-step"><b>1.</b> 电脑 USB 串口直连 STM32 UART3，并确保共地。</div>
-              <div class="stm32-step"><b>2.</b> 点击“前往直连调试”进入串口连接页，选择本地串口（默认 115200）。</div>
-              <div class="stm32-step"><b>3.</b> 回到本页点击“发起联通测试”，发送零速度 11 字节指令帧。</div>
-              <div class="stm32-step"><b>4.</b> 若收到 24 字节遥测，即判定直连链路正常。</div>
-          </div>
-        </div>
-      </div>
-
-      <div class="card">
-        <div class="card-head">测试说明</div>
-        <div class="card-body" style="font-size:.8em;color:var(--muted);line-height:1.8;">
-          联通测试发送帧格式：<span style="font-family:monospace;color:var(--text);">7B 00 00 00 00 00 00 00 00 BCC 7D</span><br>
-          若仅显示“单向连通”，通常是 STM32→A1 回传线（PB10 → A1 RX）未接通。
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-
-<!-- ═══ Chassis Page ═════════════════════════════════════════════════════════ -->
-<div class="page" id="page-chassis">
-  <div class="workspace">
-
-    <!-- ── 模块一：直连 STM32 ── -->
-    <div class="card chs-conn mode-direct-only">
-      <div class="card-head">模块一 · 电脑直连 STM32</div>
-      <div class="card-body">
-        <div class="form-row">
-          <label>端口</label>
-          <select id="portSelect"></select>
-          <button class="btn btn-ghost" style="padding:5px 10px;" onclick="refreshPorts()" title="刷新端口">⟳</button>
-        </div>
-        <div style="display:flex;gap:8px;margin-top:6px;">
-          <button class="btn btn-ghost" style="flex:1;justify-content:center;" onclick="refreshPorts()">⟳ 刷新列表</button>
-          <button class="btn btn-blue" style="flex:1;justify-content:center;" onclick="scanNewPorts()">🔍 扫描新串口</button>
-        </div>
-        <div class="form-row">
-          <label>波特率</label>
-          <select id="baudSelect">
-            <option value="115200" selected>115200</option>
-            <option value="9600">9600</option>
-            <option value="57600">57600</option>
-            <option value="230400">230400</option>
-          </select>
-        </div>
-        <div style="display:flex;gap:8px;margin-top:6px;">
-          <button class="btn btn-green" id="connectBtn" onclick="connectChassis()" style="flex:1;">🔌 连接</button>
-          <button class="btn btn-red" id="disconnectBtn" onclick="disconnectChassis()" style="flex:1;" disabled>✕ 断开</button>
-        </div>
-        <div id="chsConnMsg" style="font-size:.75em;color:var(--muted);margin-top:8px;"></div>
-        <div id="portScanHint" style="font-size:.74em;color:var(--muted);margin-top:6px;line-height:1.45;"></div>
-        <div class="divider"></div>
-        <div style="font-size:.75em;color:var(--muted);">
-          <div style="margin-bottom:4px;font-weight:600;color:var(--text);">协议参数</div>
-          <div>帧头: <span style="color:var(--red);font-family:monospace;">0x7B</span> &nbsp; 帧尾: <span style="color:var(--red);font-family:monospace;">0x7D</span></div>
-          <div style="margin-top:3px;">指令帧: <span style="font-family:monospace;color:var(--blue);">11</span> 字节 → STM32</div>
-          <div>遥测帧: <span style="font-family:monospace;color:var(--green);">24</span> 字节 ← STM32</div>
-          <div style="margin-top:3px;">校验: <span style="font-family:monospace;color:var(--purple);">XOR(bytes[0..N-2])</span></div>
-        </div>
-        <div class="divider"></div>
-        <div class="mini-note">这是 PC 通过 USB 串口直接调试运动模块的链路。若下方 ROS 模块需要占用同一串口，请先断开这里的直连连接。</div>
-      </div>
-    </div>
-
-    <!-- ── 实时遥测 ── -->
-    <div class="card chs-tele">
-      <div class="card-head">
-        <span>实时遥测</span>
-        <span id="teleTargetLabel" style="color:var(--muted);font-size:.85em;">当前目标：电脑直连 STM32</span>
-      </div>
-      <div class="card-body">
-        <div id="teleTs" class="mini-note" style="margin-bottom:8px;">—</div>
-        <div class="tele-grid" style="margin-bottom:8px;">
-          <div class="tele-item">
-            <div class="tele-label">Vx 线速度</div>
-            <div class="tele-value" id="tVx">— mm/s</div>
-          </div>
-          <div class="tele-item">
-            <div class="tele-label">Vy 线速度</div>
-            <div class="tele-value" id="tVy">— mm/s</div>
-          </div>
-          <div class="tele-item">
-            <div class="tele-label">Vz 角速度</div>
-            <div class="tele-value" id="tVz">— mrad/s</div>
-          </div>
-          <div class="tele-item">
-            <div class="tele-label">电池电压</div>
-            <div class="tele-value" id="tVolt" style="color:var(--amber);">— V</div>
-          </div>
-        </div>
-        <div class="tele-imu-row">
-          <div class="tele-imu-label">加速度计 (m/s²)</div>
-          <div class="tele-imu-values">
-            <span id="tAx">X: —</span>
-            <span id="tAy">Y: —</span>
-            <span id="tAz">Z: —</span>
-          </div>
-        </div>
-        <div class="tele-imu-row" style="margin-bottom:0;">
-          <div class="tele-imu-label">陀螺仪 (rad/s)</div>
-          <div class="tele-imu-values">
-            <span id="tGx">X: —</span>
-            <span id="tGy">Y: —</span>
-            <span id="tGz">Z: —</span>
-          </div>
-        </div>
-        <div class="divider"></div>
-        <div style="display:flex;align-items:center;gap:8px;font-size:.78em;">
-          <span style="color:var(--muted);">电机状态:</span>
-          <span id="tFlagStop" style="font-weight:700;color:var(--green);">正常 ●</span>
-        </div>
-        <div class="divider"></div>
-        <div class="mini-note">此面板跟随当前控制目标切换。选择 A1 Relay 时，这里读取的是远端 A1 Companion 返回的 STM32 遥测。</div>
-      </div>
-    </div>
-
-    <!-- ── 接线参考 ── -->
-    <div class="card chs-wiring">
-      <div class="card-head" style="justify-content:space-between;">
-        <span>接线参考</span>
-        <div style="display:flex;gap:6px;">
-          <span class="mode-badge badge-ros">A1 接法</span>
-          <span class="mode-badge badge-pc">PC 调试接法</span>
-        </div>
-      </div>
-      <div class="card-body">
-        <div style="font-size:.75em;color:var(--muted);margin-bottom:8px;">STM32 WHEELTEC C50X 使用 UART3 (PB10/PB11) 接收控制指令</div>
-        <table class="wire-table">
-          <thead>
-            <tr><th>场景</th><th>发送端 (TX)</th><th>→</th><th>接收端 (RX)</th><th>说明</th></tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td><span class="mode-badge badge-ros">A1→STM</span></td>
-              <td><span class="wire-pin pin-a1">GPIO_PIN_0 (UART0 TX)</span></td>
-              <td>→</td>
-              <td><span class="wire-pin pin-stm">PB11 (UART3 RX)</span></td>
-              <td style="color:var(--muted);font-size:.85em;">A1 控制 STM32</td>
-            </tr>
-            <tr>
-              <td><span class="mode-badge badge-ros">STM→A1</span></td>
-              <td><span class="wire-pin pin-stm">PB10 (UART3 TX)</span></td>
-              <td>→</td>
-              <td><span class="wire-pin pin-a1">GPIO_PIN_2 (UART0 RX)</span></td>
-              <td style="color:var(--muted);font-size:.85em;">遥测回传</td>
-            </tr>
-            <tr>
-              <td><span class="mode-badge badge-ros">共地</span></td>
-              <td colspan="2"><span class="wire-pin pin-gnd">A1 GND</span></td>
-              <td><span class="wire-pin pin-gnd">STM32 GND</span></td>
-              <td style="color:var(--muted);font-size:.85em;">必须共地</td>
-            </tr>
-            <tr>
-              <td><span class="mode-badge badge-pc">PC TX</span></td>
-              <td><span class="wire-pin pin-pc">USB串口 TX</span></td>
-              <td>→</td>
-              <td><span class="wire-pin pin-stm">PB11 (UART3 RX)</span></td>
-              <td style="color:var(--muted);font-size:.85em;">PC 调试用</td>
-            </tr>
-            <tr>
-              <td><span class="mode-badge badge-pc">PC RX</span></td>
-              <td><span class="wire-pin pin-stm">PB10 (UART3 TX)</span></td>
-              <td>→</td>
-              <td><span class="wire-pin pin-pc">USB串口 RX</span></td>
-              <td style="color:var(--muted);font-size:.85em;">PC 接收遥测</td>
-            </tr>
-          </tbody>
-        </table>
-        <div style="font-size:.72em;color:var(--muted);margin-top:8px;">⚠️ A1 GPIO UART 为 3.3V TTL 电平；STM32 UART3 同为 3.3V，可直连，<strong style="color:var(--amber);">勿接 5V</strong></div>
-        <div class="divider"></div>
-        <div style="font-size:.75em;color:var(--muted);margin-bottom:4px;font-weight:600;">指令帧结构 (11字节: A1→STM32)</div>
-        <div class="proto-frame">
-          <div class="proto-byte hex-header">7B<span class="addr">[0]帧头</span></div>
-          <div class="proto-byte hex-cmd">Cmd<span class="addr">[1]命令</span></div>
-          <div class="proto-byte" style="background:rgba(139,148,158,.1);color:var(--muted)">00<span class="addr">[2]保留</span></div>
-          <div class="proto-byte hex-vel">Vx_H<span class="addr">[3]</span></div>
-          <div class="proto-byte hex-vel">Vx_L<span class="addr">[4]</span></div>
-          <div class="proto-byte hex-vel" style="opacity:.75">Vy_H<span class="addr">[5]</span></div>
-          <div class="proto-byte hex-vel" style="opacity:.75">Vy_L<span class="addr">[6]</span></div>
-          <div class="proto-byte hex-vel" style="opacity:.5">Vz_H<span class="addr">[7]</span></div>
-          <div class="proto-byte hex-vel" style="opacity:.5">Vz_L<span class="addr">[8]</span></div>
-          <div class="proto-byte hex-bcc">BCC<span class="addr">[9]</span></div>
-          <div class="proto-byte hex-tail">7D<span class="addr">[10]帧尾</span></div>
-        </div>
-        <div style="font-size:.72em;color:var(--muted);margin-top:5px;">Cmd: 0x00=运动 · 0x01/0x02=回充 · 0x03=对接 &nbsp;|&nbsp; 速度单位: mm/s (int16 大端)</div>
-      </div>
-    </div>
-
-    <!-- ── 模块二：A1 Relay ── -->
-    <div class="card chs-relay mode-relay-only">
-      <div class="card-head">模块二 · 电脑 → A1 Relay → STM32</div>
-      <div class="card-body">
-        <div class="form-row">
-          <label>地址</label>
-          <input type="text" id="relayUrl" value="" placeholder="http://A1-IP:5803">
-        </div>
-        <div class="form-row">
-          <label>超时</label>
-          <input type="number" id="relayTimeout" value="2.5" min="0.5" step="0.5">
-        </div>
-        <div style="display:flex;gap:8px;margin-top:6px;">
-          <button class="btn btn-ghost" style="flex:1;justify-content:center;" onclick="saveRelayConfig()">保存地址</button>
-          <button class="btn btn-blue" style="flex:1;justify-content:center;" onclick="loadRelayStatus(false)">检测 Relay</button>
-        </div>
-        <div class="divider"></div>
-        <div class="form-row">
-          <label>远端口</label>
-          <select id="relayPortSelect"></select>
-          <button class="btn btn-ghost" style="padding:5px 10px;" onclick="loadRelayPorts(true)" title="刷新端口">⟳</button>
-        </div>
-        <div class="form-row">
-          <label>波特率</label>
-          <select id="relayBaudSelect">
-            <option value="115200" selected>115200</option>
-            <option value="9600">9600</option>
-            <option value="57600">57600</option>
-            <option value="230400">230400</option>
-          </select>
-        </div>
-        <div style="display:flex;gap:8px;margin-top:6px;">
-          <button class="btn btn-green" id="relayConnectBtn" onclick="connectRelay()" style="flex:1;">连接 Relay</button>
-          <button class="btn btn-red" id="relayDisconnectBtn" onclick="disconnectRelay()" style="flex:1;" disabled>断开</button>
-        </div>
-        <div id="relayConnMsg" style="font-size:.75em;color:var(--muted);margin-top:8px;"></div>
-        <div class="divider"></div>
-        <div class="state-line">Relay 状态：<b id="relayReachability">未检测</b></div>
-        <div class="state-line">远端模型：<b id="relayModelName">—</b></div>
-        <div class="mini-note" style="margin-top:8px;">该模块用于验证 PC 下发到 A1，再由 A1 通过自身串口转发到 STM32 的完整链路。</div>
-      </div>
-    </div>
-
-    <!-- ── 运动控制 ── -->
-    <div class="card chs-motion">
-      <div class="card-head">
-        <span>运动控制</span>
-        <span style="font-size:.85em;color:var(--muted);"><kbd class="kbd">W</kbd><kbd class="kbd">A</kbd><kbd class="kbd">S</kbd><kbd class="kbd">D</kbd><kbd class="kbd">空格=急停</kbd></span>
-      </div>
-      <div class="card-body">
-        <div class="target-switch">
-          <button class="source-chip active" type="button" id="targetDirectBtn" onclick="setControlTarget('direct')">模块一 · 直连 STM32</button>
-          <button class="source-chip" type="button" id="targetRelayBtn" onclick="setControlTarget('relay')">模块二 · A1 Relay</button>
-        </div>
-        <div style="display:flex;justify-content:flex-end;margin-bottom:8px;">
-          <button class="btn btn-ghost" style="padding:5px 10px;" onclick="refreshControlStatuses()">⟳ 刷新状态</button>
-        </div>
-        <div class="speed-row">
-          <label>线速度</label>
-          <input type="range" id="linSpeed" min="50" max="500" value="200" oninput="document.getElementById('linSpeedVal').textContent=this.value">
-          <span class="speed-val"><span id="linSpeedVal">200</span> mm/s</span>
-        </div>
-        <div class="speed-row">
-          <label>角速度</label>
-          <input type="range" id="angSpeed" min="100" max="1500" value="500" oninput="document.getElementById('angSpeedVal').textContent=this.value">
-          <span class="speed-val"><span id="angSpeedVal">500</span> mrad/s</span>
-        </div>
-        <div class="joystick-wrap">
-          <div class="dpad">
-            <div class="dpad-empty"></div>
-            <div class="dpad-btn" id="btn-fwd"  onmousedown="startMove(0, 'btn-fwd')" onmouseup="stopMove(0, 'btn-fwd')" onmouseleave="stopMove(0, 'btn-fwd')" ontouchstart="startMove(0, 'btn-fwd')" ontouchend="stopMove(0, 'btn-fwd')" ontouchcancel="stopMove(0, 'btn-fwd')">↑</div>
-            <div class="dpad-empty"></div>
-            <div class="dpad-btn" id="btn-left" onmousedown="startMove(3, 'btn-left')" onmouseup="stopMove(3, 'btn-left')" onmouseleave="stopMove(3, 'btn-left')" ontouchstart="startMove(3, 'btn-left')" ontouchend="stopMove(3, 'btn-left')" ontouchcancel="stopMove(3, 'btn-left')">←</div>
-            <div class="dpad-btn stop-center" onclick="emergencyStop()">STOP</div>
-            <div class="dpad-btn" id="btn-right" onmousedown="startMove(2, 'btn-right')" onmouseup="stopMove(2, 'btn-right')" onmouseleave="stopMove(2, 'btn-right')" ontouchstart="startMove(2, 'btn-right')" ontouchend="stopMove(2, 'btn-right')" ontouchcancel="stopMove(2, 'btn-right')">→</div>
-            <div class="dpad-empty"></div>
-            <div class="dpad-btn" id="btn-back"  onmousedown="startMove(1, 'btn-back')" onmouseup="stopMove(1, 'btn-back')" onmouseleave="stopMove(1, 'btn-back')" ontouchstart="startMove(1, 'btn-back')" ontouchend="stopMove(1, 'btn-back')" ontouchcancel="stopMove(1, 'btn-back')">↓</div>
-            <div class="dpad-empty"></div>
-          </div>
-        </div>
-        <div style="font-size:.72em;color:var(--muted);text-align:center;margin-top:4px;"><span id="moveTargetHint">当前控制目标：电脑直连 STM32</span><br>按住方向键持续运动 · 松开自动停车</div>
-      </div>
-    </div>
-
-    <!-- ── ROS 直连调试 ── -->
-    <div class="card chs-ros mode-direct-only">
-      <div class="card-head">ROS 直连调试模块</div>
-      <div class="card-body">
-        <div class="form-row">
-          <label>ROS 串口</label>
-          <input type="text" id="rosPortInput" value="COM7" placeholder="COM7 / /dev/wheeltec_controller">
-          <button class="btn btn-ghost" style="padding:5px 10px;" onclick="useCurrentDirectPortForRos()" title="同步直连串口">同步</button>
-        </div>
-        <div class="form-row">
-          <label>波特率</label>
-          <input type="number" id="rosBaudInput" value="115200" min="9600" step="100">
-        </div>
-        <div style="display:flex;gap:8px;margin-top:6px;">
-          <button class="btn btn-blue" style="flex:1;" onclick="startRosNode('wheeltec_robot_node')">启动底盘节点</button>
-          <button class="btn btn-ghost" style="flex:1;" onclick="stopRosNode('wheeltec_robot_node')">停止</button>
-        </div>
-        <div style="display:flex;gap:8px;margin-top:8px;">
-          <button class="btn btn-amber" style="flex:1;" onclick="startRosNode('multi_avoidance')">启动避障节点</button>
-          <button class="btn btn-ghost" style="flex:1;" onclick="stopRosNode('multi_avoidance')">停止</button>
-        </div>
-        <div class="divider"></div>
-        <div class="form-row" style="align-items:flex-start;">
-          <label style="padding-top:3px;">联动</label>
-          <div style="display:grid;grid-template-columns:1fr;gap:6px;flex:1;font-size:.78em;color:var(--muted);">
-            <label><input type="checkbox" id="rosAutomationEnabled" onchange="applyRosConfig(true)"> 启用 YOLO 快照轮询</label>
-            <label><input type="checkbox" id="rosForwardEnabled" onchange="applyRosConfig(false)" checked> 识别 forward -> ROS 前进</label>
-            <label><input type="checkbox" id="rosBackwardEnabled" onchange="applyRosConfig(false)" checked> 识别 backward -> ROS 后退</label>
-            <label><input type="checkbox" id="rosStopEnabled" onchange="applyRosConfig(false)" checked> 识别 stop -> ROS 停车</label>
-            <label><input type="checkbox" id="rosObstacleEnabled" onchange="applyRosConfig(false)" checked> 识别 obstacle_box -> multi_avoidance</label>
-          </div>
-        </div>
-        <div class="form-row">
-          <label>线速度</label>
-          <input type="number" id="rosForwardLinear" value="0.18" min="0.01" max="1.50" step="0.01">
-        </div>
-        <div class="form-row">
-          <label>视场角</label>
-          <input type="number" id="rosCameraFov" value="60" min="20" max="150" step="1">
-        </div>
-        <div style="display:flex;gap:8px;margin-top:8px;">
-          <button class="btn btn-ghost" style="flex:1;" onclick="loadRosStatus(false)">⟳ 刷新状态</button>
-          <button class="btn btn-ghost" style="flex:1;" onclick="triggerDetectSnapshot(true)">执行快照</button>
-        </div>
-        <div style="display:flex;gap:8px;margin-top:8px;">
-          <button class="btn btn-blue" style="flex:1;" onclick="testRosForward()">ROS 前进</button>
-          <button class="btn btn-red" style="flex:1;" onclick="stopRosMotion()">ROS 停车</button>
-        </div>
-        <div id="rosStatusMsg" class="mini-note" style="margin-top:8px;">等待 ROS 状态…</div>
-        <div class="divider"></div>
-        <div class="state-line">底盘节点：<b id="rosChassisState">未运行</b></div>
-        <div class="state-line">避障节点：<b id="rosAvoidState">未运行</b></div>
-        <div class="state-line">视觉动作：<b id="rosActionSummary">idle</b></div>
-        <div class="state-line">最近快照：<b id="rosDetectSummary">尚未执行</b></div>
-        <div class="mini-note" style="margin-top:8px;margin-bottom:8px;">这里复用 src/ros2_ws 中的 wheeltec_robot_node 与 multi_avoidance。obstacle_box 会被映射成 object_tracker/current_position 话题输入。</div>
-        
-        <!-- A1 摄像头端 OSD 预览 -->
-        <div class="divider"></div>
-        <div class="form-row" style="margin-bottom:6px;">
-          <label style="font-weight:600;color:var(--text);">A1 监控</label>
-          <label style="font-size:.78em;color:var(--muted);"><input type="checkbox" id="enableA1Webcam" onchange="toggleA1Webcam(this.checked)" checked> 开启画面流</label>
-        </div>
-        <div style="width:100%;aspect-ratio:16/9;background:#000;border-radius:4px;overflow:hidden;position:relative;">
-          <img id="a1FeedPreview" src="/video_feed" style="width:100%;height:100%;object-fit:contain;" alt="A1 Camera Feed" onerror="this.style.display='none';document.getElementById('a1FeedErr').style.display='flex';" onload="this.style.display='block';document.getElementById('a1FeedErr').style.display='none';">
-          <div id="a1FeedErr" style="display:none;position:absolute;inset:0;align-items:center;justify-content:center;color:#666;font-size:0.8em;">未拉取到视频流</div>
-        </div>
-        <div style="display:grid;grid-template-columns:1fr 1fr;gap:6px;margin-top:8px;">
-          <div class="mini-note" style="text-align:center;padding:4px;" id="gestureForwardState">前进指令：<b style="color:var(--muted);">未检出</b></div>
-          <div class="mini-note" style="text-align:center;padding:4px;" id="gestureBackwardState">后退指令：<b style="color:var(--muted);">未检出</b></div>
-        </div>
-      </div>
-    </div>
-
-    <!-- ── 原始帧发送 ── -->
-    <div class="card chs-rawsend">
-      <div class="card-head">原始帧发送</div>
-      <div class="card-body">
-        <div class="mini-note" id="rawTargetLabel" style="margin-bottom:8px;">当前目标：电脑直连 STM32</div>
-        <div style="font-size:.75em;color:var(--muted);margin-bottom:6px;">输入十六进制字节 (空格分隔)，直接发送到当前目标模块</div>
-        <textarea id="rawHexInput" class="raw-send-area" style="width:100%;height:72px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);padding:6px 8px;resize:none;" placeholder="7B 00 00 00 C8 00 00 00 00 XX 7D"></textarea>
-        <div style="display:flex;gap:7px;margin-top:7px;">
-          <button class="btn btn-amber" style="flex:1;" onclick="sendRawFrame()">▶ 发送</button>
-          <button class="btn btn-ghost" onclick="buildQuickFrame()">⚡ 填充示例</button>
-        </div>
-        <div id="rawResult" style="font-size:.72em;color:var(--muted);margin-top:6px;font-family:monospace;"></div>
-        <div class="divider"></div>
-        <div style="font-size:.75em;color:var(--muted);margin-bottom:4px;font-weight:600;">快速指令</div>
-        <div style="display:grid;grid-template-columns:1fr 1fr;gap:5px;">
-          <button class="btn btn-ghost" style="font-size:.78em;padding:6px 8px;" onclick="quickMove(200,0,0)">⬆ 前进 200</button>
-          <button class="btn btn-ghost" style="font-size:.78em;padding:6px 8px;" onclick="quickMove(-200,0,0)">⬇ 后退 200</button>
-          <button class="btn btn-ghost" style="font-size:.78em;padding:6px 8px;" onclick="quickMove(0,0,500)">↺ 左转 500</button>
-          <button class="btn btn-ghost" style="font-size:.78em;padding:6px 8px;" onclick="quickMove(0,0,-500)">↻ 右转 500</button>
-          <button class="btn btn-red" style="font-size:.78em;padding:6px 8px;grid-column:1/-1;" onclick="emergencyStop()">⬛ 急停</button>
-        </div>
-      </div>
-    </div>
-
-    <!-- ── 链路联通测试 ── -->
-    <div class="card chs-debug">
-      <div class="card-head">
-        <span>链路联通测试</span>
-        <span id="pingBadge" style="font-size:.78em;padding:2px 8px;border-radius:10px;background:var(--surface2);color:var(--muted);">未测试</span>
-      </div>
-      <div class="card-body">
-        <div class="mini-note" id="pingTargetLabel" style="margin-bottom:8px;">当前目标：电脑直连 STM32</div>
-        <div style="font-size:.75em;color:var(--muted);margin-bottom:8px;">发送零速度指令帧，最多等待 600ms，验证当前目标链路是否能下发控制并收到 STM32 遥测。</div>
-        <div style="display:flex;gap:8px;margin-bottom:8px;">
-          <button class="btn btn-blue" style="flex:1;" id="pingBtn" onclick="runPingTest()">🔍 发起联通测试</button>
-        </div>
-        <pre id="pingResult" style="background:var(--surface2);border-radius:6px;padding:8px 10px;font-size:.72em;color:var(--text);font-family:monospace;white-space:pre-wrap;min-height:40px;margin:0;"></pre>
-        <div class="divider"></div>
-        <div style="font-size:.72em;color:var(--muted);">⚠️ 直连模式测试的是 PC→STM32；Relay 模式测试的是 PC→A1→STM32。</div>
-      </div>
-    </div>
-
-    <!-- ── 通信日志 ── -->
-    <div class="card chs-log">
-      <div class="card-head">
-        <span>通信日志</span>
-        <div style="display:flex;gap:6px;align-items:center;flex-wrap:wrap;">
-          <span id="logTargetLabel" style="font-size:.75em;color:var(--muted);padding:4px 8px;">当前目标：电脑直连 STM32</span>
-          <button class="btn btn-ghost" style="padding:3px 10px;font-size:.75em;" onclick="clearLogs()">清空</button>
-          <label style="font-size:.75em;color:var(--muted);display:flex;align-items:center;gap:4px;"><input type="checkbox" id="autoScroll" checked> 自动滚动</label>
-          <label style="font-size:.75em;color:var(--muted);display:flex;align-items:center;gap:4px;"><input type="checkbox" id="showRxLog" checked> 显示接收</label>
-        </div>
-      </div>
-      <div class="card-body" style="display:grid;grid-template-columns:1fr 1fr;gap:10px;">
+    <section class="shared-section">
+      <div class="shared-banner">
         <div>
-          <div style="font-size:.72em;color:var(--muted);margin-bottom:4px;">📤 发送帧 (TX)</div>
-          <div class="log-area" id="txLogArea"></div>
+          <div class="workflow-eyebrow">共享操作区</div>
+          <h3>联通测试、遥测、运动控制和日志会自动跟随当前页面目标</h3>
+          <p id="sharedTargetLabel">当前目标：电脑直连 STM32</p>
         </div>
-        <div>
-          <div style="font-size:.72em;color:var(--muted);margin-bottom:4px;">📥 接收帧 (RX)</div>
-          <div class="log-area" id="rxLogArea"></div>
+        <div class="mini-note">顶部页面决定 direct / relay 目标，不再需要额外切换按钮。</div>
+      </div>
+
+      <div class="workflow-grid">
+        <div class="card chs-debug">
+          <div class="card-head">
+            <span>链路联通测试</span>
+            <span id="pingBadge" style="font-size:.78em;padding:2px 8px;border-radius:10px;background:var(--color-surface-hover);color:var(--color-secondary);">未测试</span>
+          </div>
+          <div class="card-body">
+            <div class="mini-note" id="pingTargetLabel" style="margin-bottom:8px;">当前目标：电脑直连 STM32</div>
+            <div style="font-size:.75em;color:var(--color-secondary);margin-bottom:8px;">发送零速度指令帧，最多等待 600ms，验证当前目标链路是否能下发控制并收到 STM32 遥测。</div>
+            <div style="display:flex;gap:8px;margin-bottom:8px;">
+              <button class="btn btn-blue" style="flex:1;" id="pingBtn" onclick="runPingTest()">发起联通测试</button>
+            </div>
+            <pre id="pingResult" style="background:var(--color-surface-hover);border-radius:6px;padding:8px 10px;font-size:.72em;color:var(--color-primary);font-family:monospace;white-space:pre-wrap;min-height:40px;margin:0;"></pre>
+            <div class="divider"></div>
+            <div style="font-size:.72em;color:var(--color-secondary);">直连模式测试的是 PC → STM32；Relay 模式测试的是 PC → A1 → STM32。</div>
+          </div>
+        </div>
+
+        <div class="card chs-tele">
+          <div class="card-head">
+            <span>实时遥测</span>
+            <span id="teleTargetLabel" style="color:var(--color-secondary);font-size:.85em;">当前目标：电脑直连 STM32</span>
+          </div>
+          <div class="card-body">
+            <div id="teleTs" class="mini-note" style="margin-bottom:8px;">—</div>
+            <div class="tele-grid" style="margin-bottom:8px;">
+              <div class="tele-item">
+                <div class="tele-label">Vx 线速度</div>
+                <div class="tele-value" id="tVx">— mm/s</div>
+              </div>
+              <div class="tele-item">
+                <div class="tele-label">Vy 线速度</div>
+                <div class="tele-value" id="tVy">— mm/s</div>
+              </div>
+              <div class="tele-item">
+                <div class="tele-label">Vz 角速度</div>
+                <div class="tele-value" id="tVz">— mrad/s</div>
+              </div>
+              <div class="tele-item">
+                <div class="tele-label">电池电压</div>
+                <div class="tele-value amber" id="tVolt">— V</div>
+              </div>
+            </div>
+            <div class="tele-imu-row">
+              <div class="tele-imu-label">加速度计 (m/s²)</div>
+              <div class="tele-imu-values">
+                <span id="tAx">X: —</span>
+                <span id="tAy">Y: —</span>
+                <span id="tAz">Z: —</span>
+              </div>
+            </div>
+            <div class="tele-imu-row" style="margin-bottom:0;">
+              <div class="tele-imu-label">陀螺仪 (rad/s)</div>
+              <div class="tele-imu-values">
+                <span id="tGx">X: —</span>
+                <span id="tGy">Y: —</span>
+                <span id="tGz">Z: —</span>
+              </div>
+            </div>
+            <div class="divider"></div>
+            <div style="display:flex;align-items:center;gap:8px;font-size:.78em;">
+              <span style="color:var(--color-secondary);">电机状态:</span>
+              <span id="tFlagStop" style="font-weight:700;color:var(--color-success);">正常 ●</span>
+            </div>
+            <div class="divider"></div>
+            <div class="mini-note">此面板始终读取当前页面对应目标的遥测数据。</div>
+          </div>
+        </div>
+
+        <div class="card chs-motion">
+          <div class="card-head">
+            <span>运动控制</span>
+            <span style="font-size:.85em;color:var(--color-secondary);"><kbd class="kbd">W</kbd><kbd class="kbd">A</kbd><kbd class="kbd">S</kbd><kbd class="kbd">D</kbd><kbd class="kbd">空格=急停</kbd></span>
+          </div>
+          <div class="card-body">
+            <div style="display:flex;justify-content:flex-end;margin-bottom:8px;">
+              <button class="btn btn-ghost" style="padding:5px 10px;" onclick="refreshControlStatuses()">刷新状态</button>
+            </div>
+            <div class="speed-row">
+              <label>线速度</label>
+              <input type="range" id="linSpeed" min="50" max="500" value="200" oninput="document.getElementById('linSpeedVal').textContent=this.value">
+              <span class="speed-val"><span id="linSpeedVal">200</span> mm/s</span>
+            </div>
+            <div class="speed-row">
+              <label>角速度</label>
+              <input type="range" id="angSpeed" min="100" max="1500" value="500" oninput="document.getElementById('angSpeedVal').textContent=this.value">
+              <span class="speed-val"><span id="angSpeedVal">500</span> mrad/s</span>
+            </div>
+            <div class="joystick-wrap">
+              <div class="dpad">
+                <div class="dpad-empty"></div>
+                <div class="dpad-btn" id="btn-fwd" onmousedown="startMove(0, 'btn-fwd')" onmouseup="stopMove(0, 'btn-fwd')" onmouseleave="stopMove(0, 'btn-fwd')" ontouchstart="startMove(0, 'btn-fwd')" ontouchend="stopMove(0, 'btn-fwd')" ontouchcancel="stopMove(0, 'btn-fwd')">↑</div>
+                <div class="dpad-empty"></div>
+                <div class="dpad-btn" id="btn-left" onmousedown="startMove(3, 'btn-left')" onmouseup="stopMove(3, 'btn-left')" onmouseleave="stopMove(3, 'btn-left')" ontouchstart="startMove(3, 'btn-left')" ontouchend="stopMove(3, 'btn-left')" ontouchcancel="stopMove(3, 'btn-left')">←</div>
+                <div class="dpad-btn stop-center" onclick="emergencyStop()">STOP</div>
+                <div class="dpad-btn" id="btn-right" onmousedown="startMove(2, 'btn-right')" onmouseup="stopMove(2, 'btn-right')" onmouseleave="stopMove(2, 'btn-right')" ontouchstart="startMove(2, 'btn-right')" ontouchend="stopMove(2, 'btn-right')" ontouchcancel="stopMove(2, 'btn-right')">→</div>
+                <div class="dpad-empty"></div>
+                <div class="dpad-btn" id="btn-back" onmousedown="startMove(1, 'btn-back')" onmouseup="stopMove(1, 'btn-back')" onmouseleave="stopMove(1, 'btn-back')" ontouchstart="startMove(1, 'btn-back')" ontouchend="stopMove(1, 'btn-back')" ontouchcancel="stopMove(1, 'btn-back')">↓</div>
+                <div class="dpad-empty"></div>
+              </div>
+            </div>
+            <div style="font-size:.72em;color:var(--color-secondary);text-align:center;margin-top:4px;"><span id="moveTargetHint">当前目标：电脑直连 STM32</span><br>按住方向键持续运动 · 松开自动停车</div>
+          </div>
+        </div>
+
+        <div class="card chs-rawsend">
+          <div class="card-head">原始帧发送</div>
+          <div class="card-body">
+            <div class="mini-note" id="rawTargetLabel" style="margin-bottom:8px;">当前目标：电脑直连 STM32</div>
+            <div style="font-size:.75em;color:var(--color-secondary);margin-bottom:6px;">输入十六进制字节（空格分隔），直接发送到当前目标模块。</div>
+            <textarea id="rawHexInput" class="raw-send-area" style="width:100%;height:72px;background:var(--color-surface);border:1px solid var(--color-border);border-radius:6px;color:var(--color-primary);padding:6px 8px;resize:none;" placeholder="7B 00 00 00 C8 00 00 00 00 XX 7D"></textarea>
+            <div style="display:flex;gap:7px;margin-top:7px;">
+              <button class="btn btn-amber" style="flex:1;" onclick="sendRawFrame()">发送</button>
+              <button class="btn btn-ghost" onclick="buildQuickFrame()">填充示例</button>
+            </div>
+            <div id="rawResult" style="font-size:.72em;color:var(--color-secondary);margin-top:6px;font-family:monospace;"></div>
+            <div class="divider"></div>
+            <div style="font-size:.75em;color:var(--color-secondary);margin-bottom:4px;font-weight:600;">快速指令</div>
+            <div style="display:grid;grid-template-columns:1fr 1fr;gap:5px;">
+              <button class="btn btn-ghost" style="font-size:.78em;padding:6px 8px;" onclick="quickMove(200,0,0)">前进 200</button>
+              <button class="btn btn-ghost" style="font-size:.78em;padding:6px 8px;" onclick="quickMove(-200,0,0)">后退 200</button>
+              <button class="btn btn-ghost" style="font-size:.78em;padding:6px 8px;" onclick="quickMove(0,0,500)">左转 500</button>
+              <button class="btn btn-ghost" style="font-size:.78em;padding:6px 8px;" onclick="quickMove(0,0,-500)">右转 500</button>
+              <button class="btn btn-red" style="font-size:.78em;padding:6px 8px;grid-column:1/-1;" onclick="emergencyStop()">急停</button>
+            </div>
+          </div>
+        </div>
+
+        <div class="card chs-log span-all">
+          <div class="card-head">
+            <span>通信日志</span>
+            <div style="display:flex;gap:6px;align-items:center;flex-wrap:wrap;">
+              <span id="logTargetLabel" style="font-size:.75em;color:var(--color-secondary);padding:4px 8px;">当前目标：电脑直连 STM32</span>
+              <button class="btn btn-ghost" style="padding:3px 10px;font-size:.75em;" onclick="clearLogs()">清空</button>
+              <label style="font-size:.75em;color:var(--color-secondary);display:flex;align-items:center;gap:4px;"><input type="checkbox" id="autoScroll" checked> 自动滚动</label>
+              <label style="font-size:.75em;color:var(--color-secondary);display:flex;align-items:center;gap:4px;"><input type="checkbox" id="showRxLog" checked> 显示接收</label>
+            </div>
+          </div>
+          <div class="card-body" style="display:grid;grid-template-columns:1fr 1fr;gap:10px;">
+            <div>
+              <div style="font-size:.72em;color:var(--color-secondary);margin-bottom:4px;">发送帧 (TX)</div>
+              <div class="log-area" id="txLogArea"></div>
+            </div>
+            <div>
+              <div style="font-size:.72em;color:var(--color-secondary);margin-bottom:4px;">接收帧 (RX)</div>
+              <div class="log-area" id="rxLogArea"></div>
+            </div>
+          </div>
         </div>
       </div>
-    </div>
-
-  </div>
+    </section>
+  </main>
 </div>
 
 <div class="toast" id="toast"></div>
@@ -1270,27 +1424,32 @@ function switchStreamTab(tab) {
 
 // ── Tab switching ───────────────────────────────────────────────────────────
 function switchTab(tab) {
+  const nextTab = tab === 'chassis' ? 'chassis' : 'stm32';
   resetMotionState(true);
   document.querySelectorAll('.page').forEach(p => p.classList.remove('active'));
   document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
-  const pageEl = document.getElementById('page-' + tab);
-  const tabEl = document.getElementById('tab-' + tab);
+  const pageEl = document.getElementById('page-' + nextTab);
+  const tabEl = document.getElementById('tab-' + nextTab);
   if (!pageEl || !tabEl) {
-    toast('页面未找到: ' + tab, 'err');
+    toast('页面未找到: ' + nextTab, 'err');
     return;
   }
   pageEl.classList.add('active');
   tabEl.classList.add('active');
-  if (tab === 'camera') {
-    loadCameraDevices();
-    loadDetectModels();
+  const nextTarget = nextTab === 'chassis' ? 'relay' : 'direct';
+  if (controlTarget !== nextTarget) {
+    controlTarget = nextTarget;
+    _lastTxCount = -1;
+    _lastRxCount = -1;
   }
-  if (tab === 'chassis' || tab === 'stm32') {
-    refreshPorts();
-    loadChassisStatus(true);
-    loadRelayStatus(true);
-    loadRosStatus(true);
-  }
+  updateTargetWidgets();
+  refreshPorts();
+  loadRelayPorts(false);
+  loadChassisStatus(true);
+  loadRelayStatus(true);
+  loadRosStatus(true);
+  updateTelemetry();
+  pollLogs();
 }
 
 // ── Camera ─────────────────────────────────────────────────────────────────
@@ -1430,6 +1589,7 @@ let rosConfigInitialized = false;
 let rosSnapshotTimer = null;
 let _lastTxCount = 0;
 let _lastRxCount = 0;
+let wiringView = 'a1';
 
 function apiJson(url, options = {}) {
   return fetch(url, options).then(r => r.json());
@@ -1465,12 +1625,8 @@ function setChsStatus(online, port, target = controlTarget) {
 }
 
 function updateTargetWidgets() {
-  const directBtn = document.getElementById('targetDirectBtn');
-  const relayBtn = document.getElementById('targetRelayBtn');
-  if (directBtn) directBtn.classList.toggle('active', controlTarget === 'direct');
-  if (relayBtn) relayBtn.classList.toggle('active', controlTarget === 'relay');
   const label = '当前目标：' + targetLabel();
-  ['teleTargetLabel', 'moveTargetHint', 'pingTargetLabel', 'logTargetLabel', 'rawTargetLabel'].forEach(id => {
+  ['teleTargetLabel', 'moveTargetHint', 'pingTargetLabel', 'logTargetLabel', 'rawTargetLabel', 'sharedTargetLabel'].forEach(id => {
     const el = document.getElementById(id);
     if (el) el.textContent = label;
   });
@@ -1478,19 +1634,23 @@ function updateTargetWidgets() {
   setChsStatus(targetConnected(), currentPort, controlTarget);
 }
 
-function setControlTarget(target) {
-  const nextTarget = target === 'relay' ? 'relay' : 'direct';
-  if (controlTarget === nextTarget) {
-    updateTargetWidgets();
-    return;
+function setWiringView(view) {
+  wiringView = view === 'pc' ? 'pc' : 'a1';
+  document.querySelectorAll('[data-wiring-view-btn]').forEach(btn => {
+    const active = btn.dataset.wiringViewBtn === wiringView;
+    btn.classList.toggle('active', active);
+    btn.setAttribute('aria-pressed', active ? 'true' : 'false');
+  });
+  document.querySelectorAll('[data-wiring-view]').forEach(row => {
+    const mode = row.dataset.wiringView;
+    row.hidden = !(mode === 'all' || mode === wiringView);
+  });
+  const note = document.getElementById('wiringViewNote');
+  if (note) {
+    note.textContent = wiringView === 'pc'
+      ? 'PC 调试场景下，USB 串口直接连接 STM32 UART3，并保持和 STM32 共地。'
+      : 'A1 Relay 场景下，A1 通过 UART0 与 STM32 UART3 直连并共地。';
   }
-  resetMotionState(true);
-  controlTarget = nextTarget;
-  _lastTxCount = -1;
-  _lastRxCount = -1;
-  updateTargetWidgets();
-  updateTelemetry();
-  pollLogs();
 }
 
 function renderPortOptions(ports, markNew = false) {
@@ -1662,7 +1822,7 @@ function loadRelayStatus(silent = true) {
     relayPort = null;
     const reach = document.getElementById('relayReachability');
     reach.textContent = '未配置';
-    reach.style.color = 'var(--muted)';
+    reach.style.color = 'var(--color-secondary)';
     document.getElementById('relayModelName').textContent = '—';
     document.getElementById('relayConnMsg').textContent = '未配置 A1 Companion 地址';
     document.getElementById('relayConnectBtn').disabled = true;
@@ -1676,10 +1836,10 @@ function loadRelayStatus(silent = true) {
     const reach = document.getElementById('relayReachability');
     if (d.reachable) {
       reach.textContent = '可达';
-      reach.style.color = 'var(--green)';
+      reach.style.color = 'var(--color-success)';
     } else {
       reach.textContent = d.error ? ('不可达: ' + d.error) : '不可达';
-      reach.style.color = 'var(--red)';
+      reach.style.color = 'var(--color-error)';
       if (!silent && d.error) toast('✗ ' + d.error, 'err');
     }
     document.getElementById('relayModelName').textContent = d.model_name || '—';
@@ -1696,7 +1856,7 @@ function loadRelayStatus(silent = true) {
     relayConnected = false;
     relayPort = null;
     document.getElementById('relayReachability').textContent = '不可达';
-    document.getElementById('relayReachability').style.color = 'var(--red)';
+    document.getElementById('relayReachability').style.color = 'var(--color-error)';
     document.getElementById('relayConnMsg').textContent = String(e);
     if (!silent) toast('✗ ' + e, 'err');
     if (controlTarget === 'relay') setChsStatus(false, null, 'relay');
@@ -1844,7 +2004,7 @@ function runPingTest(scope = 'chassis') {
   }
   btn.disabled = true;
   badge.textContent = '测试中…';
-  badge.style.background = 'var(--amber)';
+  badge.style.background = 'var(--color-warning)';
   badge.style.color = '#000';
   result.textContent = '正在测试 ' + targetLabel() + ' 链路…';
 
@@ -1852,14 +2012,14 @@ function runPingTest(scope = 'chassis') {
     btn.disabled = false;
     if (!d.success) {
       badge.textContent = '失败';
-      badge.style.background = 'var(--red)';
+      badge.style.background = 'var(--color-error)';
       badge.style.color = '#fff';
       result.textContent = '✗ 错误: ' + (d.error || '未知');
       return;
     }
     if (d.connected) {
       badge.textContent = '双向连通 ✓';
-      badge.style.background = 'var(--green)';
+      badge.style.background = 'var(--color-success)';
       badge.style.color = '#fff';
       const t = d.telemetry || {};
       result.textContent =
@@ -1873,7 +2033,7 @@ function runPingTest(scope = 'chassis') {
         `  电池   ${t.voltage?.toFixed(2)} V`;
     } else {
       badge.textContent = '单向连通';
-      badge.style.background = 'var(--amber)';
+      badge.style.background = 'var(--color-warning)';
       badge.style.color = '#000';
       result.textContent =
         `⚠️ 目标链路: ${targetLabel()}\n` +
@@ -1884,7 +2044,7 @@ function runPingTest(scope = 'chassis') {
   }).catch(e => {
     btn.disabled = false;
     badge.textContent = '错误';
-    badge.style.background = 'var(--red)';
+    badge.style.background = 'var(--color-error)';
     badge.style.color = '#fff';
     result.textContent = '✗ 网络错误: ' + e;
   });
@@ -1936,10 +2096,10 @@ function sendRawFrame() {
   }).then(d => {
     const res = document.getElementById('rawResult');
     if (d.success) {
-      res.style.color = 'var(--green)';
+      res.style.color = 'var(--color-success)';
       res.textContent = '✓ 已发送 ' + d.bytes_sent + ' 字节';
     } else {
-      res.style.color = 'var(--red)';
+      res.style.color = 'var(--color-error)';
       res.textContent = '✗ ' + d.error;
     }
   }).catch(() => {});
@@ -1958,7 +2118,7 @@ function colorHexFrame(hex, isTx) {
     return [
       `<span class="hex-byte hex-header">${bytes[0]}</span>`,
       `<span class="hex-byte hex-cmd">${bytes[1]}</span>`,
-      `<span class="hex-byte" style="color:var(--muted)">${bytes[2]}</span>`,
+      `<span class="hex-byte" style="color:var(--color-secondary)">${bytes[2]}</span>`,
       `<span class="hex-byte hex-vel">${bytes[3]}</span>`,
       `<span class="hex-byte hex-vel">${bytes[4]}</span>`,
       `<span class="hex-byte hex-vel">${bytes[5]}</span>`,
@@ -1981,7 +2141,7 @@ function pollLogs() {
       area.innerHTML = logs.map(l => `
         <div><span class="log-ts">${l.ts}</span>
         <span class="log-tx">${colorHexFrame(l.hex, true)}</span>
-        ${l.raw ? '' : ` <span style="color:var(--muted);font-size:.9em;">Vx=${l.vx} Vy=${l.vy} Vz=${l.vz}</span>`}
+        ${l.raw ? '' : ` <span style="color:var(--color-secondary);font-size:.9em;">Vx=${l.vx} Vy=${l.vy} Vz=${l.vz}</span>`}
         </div>`).join('');
       if (document.getElementById('autoScroll').checked) area.scrollTop = 0;
     }
@@ -1996,7 +2156,7 @@ function pollLogs() {
       area.innerHTML = logs.map(l => {
         const tail = l.data ? ` V=${l.data.voltage}V Vx=${l.data.vx}` : '';
         const preview = (l.hex || '').length > 47 ? (l.hex.substring(0, 47) + '…') : (l.hex || '');
-        return `<div><span class="log-ts">${l.ts}</span><span class="log-rx" style="font-size:.8em;">${preview}</span><span style="color:var(--muted);font-size:.8em;">${tail}</span></div>`;
+        return `<div><span class="log-ts">${l.ts}</span><span class="log-rx" style="font-size:.8em;">${preview}</span><span style="color:var(--color-secondary);font-size:.8em;">${tail}</span></div>`;
       }).join('');
       if (document.getElementById('autoScroll').checked) area.scrollTop = 0;
     }
@@ -2051,7 +2211,7 @@ function updateTelemetry() {
     document.getElementById('tGz').textContent = 'Z: ' + t.gyro_z.toFixed(3);
     const fs = document.getElementById('tFlagStop');
     fs.textContent = t.flag_stop === 0 ? '正常 ●' : '失控 ●';
-    fs.style.color = t.flag_stop === 0 ? 'var(--green)' : 'var(--red)';
+    fs.style.color = t.flag_stop === 0 ? 'var(--color-success)' : 'var(--color-error)';
   }).catch(() => {});
 }
 
@@ -2222,31 +2382,16 @@ function updateRosSnapshotView(data) {
   
   const fwdState = document.getElementById('gestureForwardState');
   if (fwdCount > 0) {
-    fwdState.innerHTML = `前进指令：<b style="color:var(--primary);">已检出(${fwdCount})</b>`;
+    fwdState.innerHTML = `前进指令：<b style="color:var(--color-success);">已检出(${fwdCount})</b>`;
   } else {
-    fwdState.innerHTML = `前进指令：<b style="color:var(--muted);">未检出</b>`;
+    fwdState.innerHTML = `前进指令：<b style="color:var(--color-secondary);">未检出</b>`;
   }
   
   const bwdState = document.getElementById('gestureBackwardState');
   if (bwdCount > 0) {
-    bwdState.innerHTML = `后退指令：<b style="color:var(--amber);">已检出(${bwdCount})</b>`;
+    bwdState.innerHTML = `后退指令：<b style="color:var(--color-warning);">已检出(${bwdCount})</b>`;
   } else {
-    bwdState.innerHTML = `后退指令：<b style="color:var(--muted);">未检出</b>`;
-  }
-}
-
-function toggleA1Webcam(enabled) {
-  const imgEL = document.getElementById('a1FeedPreview');
-  const errEL = document.getElementById('a1FeedErr');
-  if (enabled) {
-    imgEL.src = '/video_feed?' + Date.now();
-    imgEL.style.display = 'block';
-    errEL.style.display = 'none';
-  } else {
-    imgEL.src = '';
-    imgEL.style.display = 'none';
-    errEL.style.display = 'flex';
-    errEL.textContent = '流已暂停';
+    bwdState.innerHTML = `后退指令：<b style="color:var(--color-secondary);">未检出</b>`;
   }
 }
 
@@ -2343,14 +2488,12 @@ refreshPorts();
 fetchGallery();
 loadCameraDevices();
 loadDetectModels();
-updateTargetWidgets();
-loadRelayConfig();
-loadRelayPorts(false);
-loadChassisStatus(true);
-loadRelayStatus(true);
-loadRosStatus(true);
-updateTelemetry();
-pollLogs();
+loadRelayConfig().then(() => {
+  loadRelayPorts(false);
+  loadRelayStatus(true);
+});
+setWiringView('a1');
+switchTab('stm32');
 </script>
 </body>
 </html>

--- a/tools/aurora/templates/companion_ui.html
+++ b/tools/aurora/templates/companion_ui.html
@@ -8,167 +8,187 @@
 @import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;700&family=Noto+Sans+SC:wght@400;500;700&display=swap');
 
 :root {
-  --bg:       #06121a;
-  --bg-soft:  #0b1b26;
-  --surface:  #102330;
-  --surface2: #153242;
-  --border:   #2b4d61;
-  --muted:    #95b3c4;
-  --text:     #eaf7ff;
-  --blue:     #2fb6ff;
-  --green:    #2bd380;
-  --purple:   #9d8bff;
-  --red:      #ff5f5f;
-  --amber:    #ffb347;
-  --orange:   #ff8a3d;
-  --teal:     #00d1c7;
-  --radius:   10px;
+  /* Color System */
+  --color-primary: #111827; 
+  --color-secondary: #6b7280;
+  --color-tertiary: #9ca3af;
+  
+  --color-bg: #f8f9fa;
+  --color-surface: #ffffff;
+  --color-surface-hover: #f3f4f6;
+  --color-border: #e5e7eb;
+  
+  --color-brand: #2563eb;
+  --color-brand-hover: #1d4ed8;
+
+  --color-success: #16a34a;
+  --color-warning: #d97706;
+  --color-error: #dc2626;
+
+  /* Typography */
+  --text-xs: 12px;
+  --text-sm: 14px;
+  --text-base: 16px;
+  --text-lg: 20px;
+  --text-xl: 24px;
+  --text-2xl: 32px;
+
+  /* Spacing */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-12: 48px;
+  --space-16: 64px;
+
+  --radius: 8px;
+  --shadow-1: 0 1px 3px rgba(0,0,0,0.08);
+  --shadow-2: 0 4px 12px rgba(0,0,0,0.1);
 }
 *{margin:0;padding:0;box-sizing:border-box;}
 body{
-  background:
-    radial-gradient(1000px 420px at 88% -10%, rgba(47,182,255,.26), transparent 55%),
-    radial-gradient(760px 340px at 8% -14%, rgba(255,138,61,.20), transparent 58%),
-    linear-gradient(165deg, #041017 0%, #071a25 52%, #081e2a 100%);
-  color:var(--text);
-  font-family:'Noto Sans SC', 'Segoe UI', sans-serif;
-  min-height:100vh;
-  display:flex;
-  flex-direction:column;
+  background: var(--color-bg);
+  color: var(--color-primary);
+  font-family: 'Noto Sans SC', 'Segoe UI', sans-serif;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  font-size: var(--text-sm);
+  font-weight: 400;
+  line-height: 1.5;
 }
 
 /* ── Topbar ───────────────────────────────────────── */
 .topbar{
-  background:linear-gradient(90deg,rgba(16,35,48,.92),rgba(19,48,64,.92));
-  backdrop-filter:blur(14px);
-  border-bottom:1px solid var(--border);
-  padding:0 20px;
-  display:flex;align-items:center;gap:0;
-  box-shadow:0 8px 26px rgba(0,0,0,.35);
-  position:sticky;top:0;z-index:200;
-  height:54px;
+  background: var(--color-surface);
+  border-bottom: 1px solid var(--color-border);
+  padding: 0 var(--space-4);
+  display: flex; align-items: center; gap: 0;
+  position: sticky; top: 0; z-index: 200;
+  height: var(--space-12);
 }
-.logo{display:flex;align-items:center;gap:9px;padding-right:20px;border-right:1px solid var(--border);}
-.logo-icon{width:28px;height:28px;border-radius:7px;background:linear-gradient(135deg,var(--blue),var(--orange));display:flex;align-items:center;justify-content:center;font-size:14px;}
-.logo-text{font-size:1.08em;font-family:'Space Grotesk','Noto Sans SC',sans-serif;font-weight:700;background:linear-gradient(90deg,var(--blue),var(--teal));background-clip:text;-webkit-background-clip:text;-webkit-text-fill-color:transparent;letter-spacing:.02em;}
+.logo{display:flex;align-items:center;gap:var(--space-2);padding-right:var(--space-4);border-right:1px solid var(--color-border);}
+.logo-icon{width:var(--space-6);height:var(--space-6);border-radius:var(--radius);background:var(--color-brand);color:white;display:flex;align-items:center;justify-content:center;font-size:var(--text-sm);}
+.logo-text{font-size:var(--text-base);font-family:'Space Grotesk','Noto Sans SC',sans-serif;font-weight:700;color:var(--color-primary);letter-spacing:0;}
 /* Tabs */
-.tabs{display:flex;align-items:center;gap:0;flex:1;padding-left:4px;}
+.tabs{display:flex;align-items:center;gap:0;flex:1;padding-left:var(--space-1);}
 .tab-btn{
-  height:54px;padding:0 18px;border:none;background:transparent;
-  color:var(--muted);font-size:.88em;font-weight:600;cursor:pointer;
+  height:var(--space-12);padding:0 var(--space-4);border:none;background:transparent;
+  color:var(--color-secondary);font-size:var(--text-sm);font-weight:600;cursor:pointer;
   border-bottom:2px solid transparent;transition:all .15s;
-  display:flex;align-items:center;gap:6px;
+  display:flex;align-items:center;gap:var(--space-1);
 }
-.tab-btn:hover{color:var(--text);}
-.tab-btn.active{color:var(--blue);border-bottom-color:var(--blue);text-shadow:0 0 10px rgba(47,182,255,.35);}
+.tab-btn:hover{color:var(--color-primary);}
+.tab-btn.active{color:var(--color-brand);border-bottom-color:var(--color-brand);}
 /* Right area */
-.topbar-right{display:flex;align-items:center;gap:10px;margin-left:auto;}
-.status-pill{display:flex;align-items:center;gap:6px;padding:4px 12px;border-radius:16px;border:1px solid var(--border);background:var(--bg-soft);font-size:.8em;}
-.dot{width:7px;height:7px;border-radius:50%;background:var(--green);animation:blink 2s ease-in-out infinite;}
-.dot.off{background:var(--red);animation:none;}
-@keyframes blink{0%,100%{opacity:1;}50%{opacity:.35;}}
-.chassis-pill{border-color:var(--border);} 
-.chassis-dot{background:var(--amber);}
-.chassis-dot.on{background:var(--green);animation:blink 2s ease-in-out infinite;}
-.chassis-dot.off{background:var(--red);animation:none;}
+.topbar-right{display:flex;align-items:center;gap:var(--space-2);margin-left:auto;}
+.status-pill{display:flex;align-items:center;gap:var(--space-1);padding:var(--space-1) var(--space-3);border-radius:16px;border:1px solid var(--color-border);background:var(--color-surface);font-size:var(--text-xs);}
+.dot{width:8px;height:8px;border-radius:50%;background:var(--color-success);}
+.dot.off{background:var(--color-error);}
+.chassis-pill{border-color:var(--color-border);} 
+.chassis-dot{width:8px;height:8px;border-radius:50%;background:var(--color-warning);}
+.chassis-dot.on{background:var(--color-success);}
+.chassis-dot.off{background:var(--color-error);}
 
 /* ── Tab pages ────────────────────────────────────── */
 .page{display:none;flex:1;}
 .page.active{display:flex;flex-direction:column;}
 
 /* ── Cards ────────────────────────────────────────── */
-.card{background:linear-gradient(160deg, rgba(16,35,48,.94), rgba(13,30,40,.95));border:1px solid var(--border);border-radius:var(--radius);overflow:hidden;box-shadow:0 10px 28px rgba(0,0,0,.22);animation:cardRise .34s ease both;}
+.card{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius);overflow:hidden;}
 .card-head{
-  padding:8px 14px;border-bottom:1px solid var(--border);
+  padding:var(--space-2) var(--space-3);border-bottom:1px solid var(--color-border);
   display:flex;align-items:center;justify-content:space-between;
-  font-size:.75em;font-weight:600;color:var(--muted);
-  text-transform:uppercase;letter-spacing:.06em;
+  font-size:var(--text-xs);font-weight:600;color:var(--color-secondary);
+  text-transform:uppercase;letter-spacing:0;
+  line-height: 1.25;
 }
-.card-body{padding:14px;}
-@keyframes cardRise{from{opacity:.0;transform:translateY(6px);}to{opacity:1;transform:translateY(0);}}
+.card-body{padding:var(--space-3);}
 
 /* ── Camera page layout ───────────────────────────── */
 #page-camera .workspace{
-  display:grid;grid-template-columns:1fr 300px;gap:12px;padding:12px;flex:1;
+  display:grid;grid-template-columns:1fr 300px;gap:var(--space-3);padding:var(--space-3);flex:1;
 }
 .preview-wrap{position:relative;background:#000;line-height:0;}
 .preview-wrap img{width:100%;display:block;}
-.preview-chip{position:absolute;top:8px;left:8px;background:rgba(13,17,23,.75);backdrop-filter:blur(4px);border:1px solid var(--border);border-radius:5px;padding:2px 8px;font-size:.7em;font-family:monospace;color:var(--green);}
-.preview-fps{position:absolute;top:8px;right:8px;background:rgba(13,17,23,.75);backdrop-filter:blur(4px);border:1px solid var(--border);border-radius:5px;padding:2px 8px;font-size:.7em;font-family:monospace;color:var(--muted);}
+.preview-chip{position:absolute;top:var(--space-2);left:var(--space-2);background:rgba(255,255,255,0.9);border:1px solid var(--color-border);border-radius:var(--radius);padding:var(--space-1) var(--space-2);font-size:var(--text-xs);font-family:monospace;color:var(--color-success);}
+.preview-fps{position:absolute;top:var(--space-2);right:var(--space-2);background:rgba(255,255,255,0.9);border:1px solid var(--color-border);border-radius:var(--radius);padding:var(--space-1) var(--space-2);font-size:var(--text-xs);font-family:monospace;color:var(--color-secondary);}
 
 /* 摄像头加载遮罩 */
 .stream-loading{
   position:absolute;inset:0;
-  background:rgba(6,18,26,.80);
+  background:rgba(255,255,255,0.9);
   display:none;align-items:center;justify-content:center;
-  flex-direction:column;gap:10px;
-  font-size:.92em;color:var(--muted);
+  flex-direction:column;gap:var(--space-2);
+  font-size:var(--text-sm);color:var(--color-secondary);
 }
 .stream-loading.visible{display:flex;}
 .spin-ring{
-  width:36px;height:36px;border-radius:50%;
-  border:3px solid var(--border);
-  border-top-color:var(--blue);
+  width:var(--space-8);height:var(--space-8);border-radius:50%;
+  border:3px solid var(--color-border);
+  border-top-color:var(--color-brand);
   animation:spinr .8s linear infinite;
 }
 @keyframes spinr{to{transform:rotate(360deg);}}
 
 /* 流模式 TAB 按钮（预览/检测切换） */
 .stream-tab{
-  height:26px;padding:0 10px;border:1px solid var(--border);border-radius:5px;
-  background:transparent;color:var(--muted);font-size:.76em;font-weight:600;
+  height:26px;padding:0 var(--space-2);border:1px solid var(--color-border);border-radius:var(--radius);
+  background:var(--color-surface);color:var(--color-secondary);font-size:var(--text-xs);font-weight:600;
   cursor:pointer;transition:all .12s;
 }
-.stream-tab:hover{background:var(--surface2);color:var(--text);}
-.stream-tab.active{background:var(--blue);color:#fff;border-color:var(--blue);}
+.stream-tab:hover{background:var(--color-surface-hover);color:var(--color-primary);}
+.stream-tab.active{background:var(--color-brand);color:#fff;border-color:var(--color-brand);}
 
-.source-switch{display:flex;gap:6px;flex-wrap:wrap;margin-bottom:8px;}
+.source-switch{display:flex;gap:var(--space-1);flex-wrap:wrap;margin-bottom:var(--space-2);}
 .source-chip{
-  border:1px solid var(--border);border-radius:999px;background:rgba(255,255,255,.02);
-  color:var(--muted);padding:6px 11px;font-size:.75em;font-weight:700;cursor:pointer;
+  border:1px solid var(--color-border);border-radius:16px;background:var(--color-surface);
+  color:var(--color-secondary);padding:var(--space-1) var(--space-3);font-size:var(--text-xs);font-weight:600;cursor:pointer;
   transition:all .14s;
 }
-.source-chip:hover{background:var(--surface2);color:var(--text);}
-.source-chip.active{background:rgba(47,182,255,.18);border-color:rgba(47,182,255,.4);color:var(--blue);}
-.source-desc{font-size:.74em;color:var(--muted);line-height:1.45;margin-top:6px;}
-.source-desc b{color:var(--text);}
-.mini-note{font-size:.72em;color:var(--muted);line-height:1.55;}
-.state-line{font-size:.75em;color:var(--muted);line-height:1.7;}
-.state-line b{color:var(--text);font-weight:600;}
+.source-chip:hover{background:var(--color-surface-hover);color:var(--color-primary);}
+.source-chip.active{background:var(--color-brand);color:#fff;border-color:var(--color-brand);}
+.source-desc{font-size:var(--text-xs);color:var(--color-secondary);line-height:1.5;margin-top:var(--space-1);}
+.source-desc b{color:var(--color-primary);}
+.mini-note{font-size:var(--text-xs);color:var(--color-secondary);line-height:1.5;}
+.state-line{font-size:var(--text-xs);color:var(--color-secondary);line-height:1.5;}
+.state-line b{color:var(--color-primary);font-weight:600;}
 
-.preview-badges{position:absolute;top:8px;left:8px;display:flex;flex-direction:column;gap:6px;}
+.preview-badges{position:absolute;top:var(--space-2);left:var(--space-2);display:flex;flex-direction:column;gap:var(--space-1);}
 .preview-badge{
-  display:inline-flex;align-items:center;gap:6px;background:rgba(13,17,23,.75);backdrop-filter:blur(4px);
-  border:1px solid var(--border);border-radius:5px;padding:2px 8px;font-size:.7em;font-family:monospace;color:var(--green);
+  display:inline-flex;align-items:center;gap:var(--space-1);background:rgba(255,255,255,0.9);
+  border:1px solid var(--color-border);border-radius:var(--radius);padding:var(--space-1) var(--space-2);font-size:var(--text-xs);font-family:monospace;color:var(--color-success);
 }
-.preview-badge.secondary{color:var(--muted);}
+.preview-badge.secondary{color:var(--color-secondary);}
 
 /* YOLOv8 检测信息面板 */
-.det-panel{padding:12px 14px;font-size:.79em;}
+.det-panel{padding:var(--space-3);font-size:var(--text-sm);}
 .det-panel table{width:100%;border-collapse:collapse;}
-.det-panel td{padding:3px 0;}
-.det-panel td:first-child{color:var(--muted);width:80px;}
-.det-badge{display:inline-block;background:rgba(47,182,255,.12);border:1px solid rgba(47,182,255,.35);color:var(--blue);border-radius:4px;padding:1px 6px;font-family:monospace;font-size:.85em;}
-.det-warn{margin-top:8px;color:var(--red);font-size:.78em;}
-.sidebar{display:flex;flex-direction:column;gap:10px;}
-.counter-box{text-align:center;padding:16px 0 8px;}
-.counter-num{font-size:3em;font-weight:800;line-height:1;background:linear-gradient(135deg,var(--blue),var(--teal));background-clip:text;-webkit-background-clip:text;-webkit-text-fill-color:transparent;}
-.counter-lbl{font-size:.7em;color:var(--muted);margin-top:3px;}
+.det-panel td{padding:var(--space-1) 0;}
+.det-panel td:first-child{color:var(--color-secondary);width:80px;}
+.det-badge{display:inline-block;background:var(--color-surface-hover);border:1px solid var(--color-border);color:var(--color-primary);border-radius:var(--radius);padding:1px 6px;font-family:monospace;font-size:var(--text-xs);}
+.det-warn{margin-top:var(--space-2);color:var(--color-error);font-size:var(--text-xs);}
+.sidebar{display:flex;flex-direction:column;gap:var(--space-2);}
+.counter-box{text-align:center;padding:var(--space-4) 0 var(--space-2);}
+.counter-num{font-size:var(--text-2xl);font-weight:600;line-height:1.25;color:var(--color-primary);}
+.counter-lbl{font-size:var(--text-xs);color:var(--color-secondary);margin-top:var(--space-1);}
 
 /* Gallery */
-.gallery-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:5px;}
-.gallery-item{position:relative;border-radius:4px;overflow:hidden;background:#000;border:1px solid var(--border);transition:border-color .15s;cursor:pointer;}
-.gallery-item:hover{border-color:var(--blue);}
+.gallery-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-1);}
+.gallery-item{position:relative;border-radius:var(--radius);overflow:hidden;background:#000;border:1px solid var(--color-border);transition:border-color .15s;cursor:pointer;}
+.gallery-item:hover{border-color:var(--color-brand);}
 .gallery-item img{width:100%;display:block;}
-.gallery-item .g-lbl{position:absolute;bottom:0;left:0;right:0;background:rgba(0,0,0,.6);font-size:.55em;color:var(--muted);padding:2px 4px;text-align:center;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
-.gallery-empty{grid-column:1/-1;text-align:center;color:var(--muted);font-size:.8em;padding:14px 0;}
+.gallery-item .g-lbl{position:absolute;bottom:0;left:0;right:0;background:rgba(255,255,255,.9);font-size:var(--text-xs);color:var(--color-secondary);padding:2px var(--space-1);text-align:center;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+.gallery-empty{grid-column:1/-1;text-align:center;color:var(--color-secondary);font-size:var(--text-sm);padding:var(--space-3) 0;}
 
 /* ── Chassis page layout ──────────────────────────── */
 #page-chassis .workspace{
   display:grid;
   grid-template-columns:300px 1fr 1fr;
   grid-template-rows:auto auto auto auto;
-  gap:12px;padding:12px;align-items:start;
+  gap:var(--space-3);padding:var(--space-3);align-items:start;
 }
 /* column spans */
 .chs-conn  { grid-column:1; grid-row:1; }
@@ -183,141 +203,138 @@ body{
 
 /* ── Buttons ──────────────────────────────────────── */
 .btn{
-  padding:9px 14px;border:1px solid transparent;border-radius:7px;
-  font-size:.88em;font-weight:600;cursor:pointer;
-  display:inline-flex;align-items:center;gap:7px;
-  transition:transform .1s,box-shadow .1s,background .12s;
-  white-space:nowrap;
+  padding:var(--space-2) var(--space-3);border:1px solid var(--color-border);border-radius:var(--radius);
+  font-size:var(--text-sm);font-weight:600;cursor:pointer;
+  display:inline-flex;align-items:center;gap:var(--space-2);
+  transition:all .1s;
+  white-space:nowrap;background:var(--color-surface);color:var(--color-primary);
 }
-.btn:active{transform:scale(.97);}
 .btn-full{width:100%;justify-content:flex-start;}
-.btn label{display:flex;flex-direction:column;align-items:flex-start;flex:1;}
-.btn small{font-weight:400;font-size:.76em;color:rgba(255,255,255,.5);margin-top:1px;}
-.btn-icon{font-size:1.2em;flex-shrink:0;}
+.btn label{display:flex;flex-direction:column;align-items:flex-start;flex:1;cursor:pointer;}
+.btn small{font-weight:400;font-size:var(--text-xs);color:var(--color-secondary);margin-top:2px;}
+.btn-icon{font-size:var(--text-base);flex-shrink:0;}
 
-.btn-blue{background:linear-gradient(135deg,#1f6feb,#388bfd);color:#fff;border-color:#1f6feb;}
-.btn-blue:hover{background:linear-gradient(135deg,#388bfd,var(--blue));box-shadow:0 3px 12px rgba(56,139,253,.4);}
-.btn-green{background:linear-gradient(135deg,#238636,#2ea043);color:#fff;border-color:#238636;}
-.btn-green:hover{background:linear-gradient(135deg,#2ea043,var(--green));box-shadow:0 3px 12px rgba(46,160,67,.4);}
-.btn-red{background:linear-gradient(135deg,#b91c1c,#dc2626);color:#fff;border-color:#b91c1c;}
-.btn-red:hover{background:linear-gradient(135deg,#dc2626,#ef4444);box-shadow:0 3px 12px rgba(220,38,38,.4);}
-.btn-ghost{background:transparent;color:var(--muted);border-color:var(--border);}
-.btn-ghost:hover{background:var(--surface2);color:var(--text);border-color:var(--blue);}
+.btn-blue{background:var(--color-brand);color:#fff;border-color:var(--color-brand);}
+.btn-blue:hover{background:var(--color-brand-hover);}
+.btn-blue small{color:rgba(255,255,255,0.8);}
+.btn-green{background:var(--color-success);color:#fff;border-color:var(--color-success);}
+.btn-green:hover{background:#15803d;} /* darker success */
+.btn-green small{color:rgba(255,255,255,0.8);}
+.btn-red{background:var(--color-error);color:#fff;border-color:var(--color-error);}
+.btn-red:hover{background:#b91c1c;}
+.btn-ghost{background:transparent;color:var(--color-primary);border-color:var(--color-border);}
+.btn-ghost:hover{background:var(--color-surface-hover);}
 .btn-ghost:disabled{opacity:.45;cursor:not-allowed;}
-.btn-amber{background:linear-gradient(135deg,#92400e,#d97706);color:#fff;border-color:#92400e;}
-.btn-amber:hover{box-shadow:0 3px 12px rgba(217,119,6,.4);}
+.btn-amber{background:var(--color-warning);color:#fff;border-color:var(--color-warning);}
+.btn-amber:hover{background:#b45309;}
 
-.divider{height:1px;background:var(--border);margin:10px 0;}
+.divider{height:1px;background:var(--color-border);margin:var(--space-2) 0;}
 
 /* ── Form inputs ──────────────────────────────────── */
-.form-row{display:flex;gap:8px;align-items:center;margin-bottom:8px;}
-.form-row label{font-size:.78em;color:var(--muted);flex-shrink:0;width:60px;}
+.form-row{display:flex;gap:var(--space-2);align-items:center;margin-bottom:var(--space-2);}
+.form-row label{font-size:var(--text-sm);color:var(--color-secondary);flex-shrink:0;width:60px;}
 select, input[type=text], input[type=number]{
-  background:var(--bg);border:1px solid var(--border);border-radius:6px;
-  color:var(--text);padding:5px 9px;font-size:.83em;flex:1;
+  background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius);
+  color:var(--color-primary);padding:var(--space-1) var(--space-2);font-size:var(--text-sm);flex:1;
 }
-select:focus, input:focus{outline:none;border-color:var(--blue);}
-select option{background:var(--surface);}
+select:focus, input:focus{outline:none;border-color:var(--color-brand);box-shadow:0 0 0 1px var(--color-brand);}
 
 /* ── Wiring table ─────────────────────────────────── */
-.wire-table{width:100%;border-collapse:collapse;font-size:.8em;}
-.wire-table th{text-align:left;color:var(--muted);padding:4px 6px;border-bottom:1px solid var(--border);font-weight:600;font-size:.75em;text-transform:uppercase;}
-.wire-table td{padding:5px 6px;border-bottom:1px solid var(--surface2);}
+.wire-table{width:100%;border-collapse:collapse;font-size:var(--text-sm);}
+.wire-table th{text-align:left;color:var(--color-secondary);padding:var(--space-1) var(--space-2);border-bottom:1px solid var(--color-border);font-weight:600;font-size:var(--text-xs);text-transform:uppercase;}
+.wire-table td{padding:var(--space-1) var(--space-2);border-bottom:1px solid var(--color-border);}
 .wire-table tr:last-child td{border-bottom:none;}
-.wire-pin{display:inline-block;padding:1px 7px;border-radius:4px;font-family:monospace;font-size:.85em;}
-.pin-a1  {background:rgba(88,166,255,.15);color:var(--blue);}
-.pin-stm {background:rgba(63,185,80,.15);color:var(--green);}
-.pin-gnd {background:rgba(248,81,73,.15);color:var(--red);}
-.pin-pc  {background:rgba(163,113,247,.15);color:var(--purple);}
-.mode-badge{display:inline-block;padding:1px 7px;border-radius:10px;font-size:.72em;font-weight:600;}
-.badge-ros{background:rgba(88,166,255,.2);color:var(--blue);}
-.badge-pc {background:rgba(163,113,247,.2);color:var(--purple);}
+.wire-pin{display:inline-block;padding:2px var(--space-2);border-radius:var(--radius);font-family:monospace;font-size:var(--text-xs);background:var(--color-surface-hover);border:1px solid var(--color-border);}
+.pin-a1  {color:var(--color-brand);}
+.pin-stm {color:var(--color-success);}
+.pin-gnd {color:var(--color-error);}
+.pin-pc  {color:var(--color-primary);}
+.mode-badge{display:inline-block;padding:2px var(--space-2);border-radius:16px;font-size:var(--text-xs);font-weight:600;}
+.badge-ros{background:var(--color-surface-hover);color:var(--color-brand);border:1px solid var(--color-border);}
+.badge-pc {background:var(--color-surface-hover);color:var(--color-primary);border:1px solid var(--color-border);}
 
 /* ── Telemetry ────────────────────────────────────── */
-.tele-grid{display:grid;grid-template-columns:1fr 1fr;gap:6px;}
-.tele-item{background:var(--surface2);border-radius:6px;padding:8px 10px;}
-.tele-label{font-size:.68em;color:var(--muted);margin-bottom:2px;text-transform:uppercase;letter-spacing:.04em;}
-.tele-value{font-size:1em;font-weight:700;font-family:monospace;color:var(--text);}
-.tele-value.green{color:var(--green);}
-.tele-value.amber{color:var(--amber);}
-.tele-value.red{color:var(--red);}
-.tele-imu-row{background:var(--surface2);border-radius:6px;padding:8px 10px;margin-bottom:6px;}
-.tele-imu-label{font-size:.68em;color:var(--muted);margin-bottom:4px;text-transform:uppercase;}
-.tele-imu-values{display:flex;gap:10px;font-size:.82em;font-family:monospace;}
-.tele-imu-values span:first-child{color:var(--red);}
-.tele-imu-values span:nth-child(2){color:var(--green);}
-.tele-imu-values span:last-child{color:var(--blue);}
+.tele-grid{display:grid;grid-template-columns:1fr 1fr;gap:var(--space-1);}
+.tele-item{background:var(--color-surface-hover);border-radius:var(--radius);padding:var(--space-2) var(--space-2);}
+.tele-label{font-size:var(--text-xs);color:var(--color-secondary);margin-bottom:2px;text-transform:uppercase;letter-spacing:0;}
+.tele-value{font-size:var(--text-sm);font-weight:600;font-family:monospace;color:var(--color-primary);}
+.tele-value.green{color:var(--color-success);}
+.tele-value.amber{color:var(--color-warning);}
+.tele-value.red{color:var(--color-error);}
+.tele-imu-row{background:var(--color-surface-hover);border-radius:var(--radius);padding:var(--space-2) var(--space-2);margin-bottom:var(--space-1);}
+.tele-imu-label{font-size:var(--text-xs);color:var(--color-secondary);margin-bottom:var(--space-1);text-transform:uppercase;}
+.tele-imu-values{display:flex;gap:var(--space-2);font-size:var(--text-sm);font-family:monospace;}
 
 /* ── Motion control ───────────────────────────────── */
-.joystick-wrap{display:flex;justify-content:center;margin:10px 0;}
-.dpad{display:grid;grid-template-columns:repeat(3,52px);grid-template-rows:repeat(3,52px);gap:4px;row-gap:4px;}
+.joystick-wrap{display:flex;justify-content:center;margin:var(--space-2) 0;}
+.dpad{display:grid;grid-template-columns:repeat(3,52px);grid-template-rows:repeat(3,52px);gap:var(--space-1);row-gap:var(--space-1);}
 .dpad-btn{
-  background:var(--surface2);border:1px solid var(--border);border-radius:8px;
-  color:var(--text);font-size:1.3em;cursor:pointer;
+  background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius);
+  color:var(--color-primary);font-size:var(--text-lg);cursor:pointer;
   display:flex;align-items:center;justify-content:center;
   transition:all .1s;user-select:none;
 }
-.dpad-btn:active, .dpad-btn.pressed{background:var(--blue);border-color:var(--blue);color:#fff;transform:scale(.94);}
-.dpad-btn.stop-center{background:rgba(248,81,73,.15);border-color:var(--red);color:var(--red);font-size:.85em;font-weight:700;}
-.dpad-btn.stop-center:active{background:var(--red);color:#fff;}
+.dpad-btn:active, .dpad-btn.pressed{background:var(--color-surface-hover);border-color:var(--color-primary);}
+.dpad-btn.stop-center{background:var(--color-error);border-color:var(--color-error);color:#fff;font-size:var(--text-xs);font-weight:600;}
+.dpad-btn.stop-center:active{background:#b91c1c;}
 .dpad-empty{visibility:hidden;}
-.speed-row{display:flex;align-items:center;gap:8px;margin-bottom:8px;}
-.speed-row label{font-size:.78em;color:var(--muted);width:70px;flex-shrink:0;}
-.speed-row input[type=range]{flex:1;accent-color:var(--blue);}
-.speed-row .speed-val{font-size:.8em;font-family:monospace;color:var(--text);width:60px;text-align:right;}
-.target-switch{display:flex;gap:6px;flex-wrap:wrap;margin-bottom:10px;}
+.speed-row{display:flex;align-items:center;gap:var(--space-2);margin-bottom:var(--space-2);}
+.speed-row label{font-size:var(--text-sm);color:var(--color-secondary);width:70px;flex-shrink:0;}
+.speed-row input[type=range]{flex:1;accent-color:var(--color-brand);}
+.speed-row .speed-val{font-size:var(--text-sm);font-family:monospace;color:var(--color-primary);width:60px;text-align:right;}
+.target-switch{display:flex;gap:var(--space-1);flex-wrap:wrap;margin-bottom:var(--space-2);}
 
 /* ── Debug logs ───────────────────────────────────── */
-.log-area{background:var(--bg);border:1px solid var(--border);border-radius:6px;padding:8px 10px;font-size:.72em;font-family:monospace;max-height:180px;overflow-y:auto;line-height:1.6;}
-.log-area .log-tx{color:var(--blue);}
-.log-area .log-rx{color:var(--green);}
-.log-area .log-err{color:var(--red);}
-.log-area .log-ts{color:var(--muted);margin-right:6px;}
+.log-area{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius);padding:var(--space-2) var(--space-2);font-size:var(--text-xs);font-family:monospace;max-height:180px;overflow-y:auto;line-height:1.5;}
+.log-area .log-tx{color:var(--color-brand);}
+.log-area .log-rx{color:var(--color-success);}
+.log-area .log-err{color:var(--color-error);}
+.log-area .log-ts{color:var(--color-secondary);margin-right:var(--space-1);}
 .hex-viewer{
-  background:var(--bg);border:1px solid var(--border);border-radius:6px;
-  padding:8px 10px;font-size:.72em;font-family:monospace;line-height:1.8;
+  background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius);
+  padding:var(--space-2) var(--space-2);font-size:var(--text-xs);font-family:monospace;line-height:1.5;
   max-height:120px;overflow-y:auto;
 }
-.hex-byte{display:inline-block;padding:1px 4px;border-radius:3px;margin:1px;}
-.hex-header{background:rgba(248,81,73,.2);color:var(--red);}
-.hex-cmd   {background:rgba(217,153,34,.2);color:var(--amber);}
-.hex-vel   {background:rgba(88,166,255,.2);color:var(--blue);}
-.hex-bcc   {background:rgba(163,113,247,.2);color:var(--purple);}
-.hex-tail  {background:rgba(248,81,73,.2);color:var(--red);}
-.hex-data  {background:rgba(63,185,80,.2);color:var(--green);}
-.raw-send-area{font-family:monospace;font-size:.82em;resize:none;}
+.hex-byte{display:inline-block;padding:1px var(--space-1);border-radius:var(--radius);margin:1px 0;background:var(--color-surface-hover);border:1px solid var(--color-border);}
+.hex-header{color:var(--color-error);}
+.hex-cmd   {color:var(--color-warning);}
+.hex-vel   {color:var(--color-brand);}
+.hex-bcc   {color:var(--color-primary);}
+.hex-tail  {color:var(--color-error);}
+.hex-data  {color:var(--color-success);}
+.raw-send-area{font-family:monospace;font-size:var(--text-sm);resize:none;}
 
 /* ── Shortcut hints ───────────────────────────────── */
-.kbd{background:var(--surface2);border:1px solid var(--border);border-radius:4px;padding:1px 6px;font-size:.7em;font-family:monospace;color:var(--muted);}
-.hint-row{display:flex;flex-wrap:wrap;gap:5px;align-items:center;margin-top:8px;}
-.hint-row span{font-size:.7em;color:var(--muted);}
+.kbd{background:var(--color-surface-hover);border:1px solid var(--color-border);border-radius:var(--radius);padding:2px var(--space-1);font-size:var(--text-xs);font-family:monospace;color:var(--color-secondary);}
+.hint-row{display:flex;flex-wrap:wrap;gap:var(--space-1);align-items:center;margin-top:var(--space-2);}
+.hint-row span{font-size:var(--text-xs);color:var(--color-secondary);}
 
 /* ── Info table ───────────────────────────────────── */
-.info-tbl{width:100%;font-size:.79em;border-collapse:collapse;}
-.info-tbl td{padding:3px 0;vertical-align:top;}
-.info-tbl td:first-child{color:var(--muted);width:80px;}
+.info-tbl{width:100%;font-size:var(--text-sm);border-collapse:collapse;}
+.info-tbl td{padding:var(--space-1) 0;vertical-align:top;}
+.info-tbl td:first-child{color:var(--color-secondary);width:80px;}
 .info-tbl td:last-child{word-break:break-all;}
 
 /* ── Toast ────────────────────────────────────────── */
-.toast{position:fixed;bottom:20px;right:20px;padding:9px 16px;border-radius:7px;font-size:.85em;font-weight:600;opacity:0;transform:translateY(6px);transition:all .2s;z-index:999;box-shadow:0 4px 20px rgba(0,0,0,.5);max-width:340px;pointer-events:none;}
+.toast{position:fixed;bottom:var(--space-6);right:var(--space-6);padding:var(--space-2) var(--space-4);border-radius:var(--radius);font-size:var(--text-sm);font-weight:600;opacity:0;transform:translateY(6px);transition:all .2s;z-index:999;box-shadow:var(--shadow-2);max-width:340px;pointer-events:none;border:1px solid var(--color-border);}
 .toast.show{opacity:1;transform:translateY(0);}
-.toast-ok{background:#238636;color:#fff;}
-.toast-err{background:#da3633;color:#fff;}
-.toast-info{background:#1f6feb;color:#fff;}
+.toast-ok{background:var(--color-surface);color:var(--color-success);border-left:4px solid var(--color-success);}
+.toast-err{background:var(--color-surface);color:var(--color-error);border-left:4px solid var(--color-error);}
+.toast-info{background:var(--color-surface);color:var(--color-brand);border-left:4px solid var(--color-brand);}
 
 /* ── Protocol reference badge ──────────────────────── */
-.proto-frame{display:flex;flex-wrap:wrap;gap:3px;margin-top:6px;}
-.proto-byte{display:inline-block;text-align:center;min-width:28px;padding:3px 5px;border-radius:4px;font-size:.68em;font-family:monospace;line-height:1.3;}
-.proto-byte .addr{color:var(--muted);font-size:.85em;display:block;}
+.proto-frame{display:flex;flex-wrap:wrap;gap:var(--space-1);margin-top:var(--space-1);}
+.proto-byte{display:inline-block;text-align:center;min-width:28px;padding:var(--space-1) var(--space-1);border-radius:var(--radius);font-size:var(--text-xs);font-family:monospace;line-height:1.5;background:var(--color-surface-hover);border:1px solid var(--color-border);}
+.proto-byte .addr{color:var(--color-secondary);font-size:var(--text-xs);display:block;}
 
 /* ── STM32 Connectivity page ───────────────────────── */
-#page-stm32 .workspace{display:grid;grid-template-columns:1.1fr .9fr;gap:12px;padding:12px;flex:1;align-items:start;}
-.stm32-hero{padding:18px 16px;background:linear-gradient(145deg,rgba(47,182,255,.12),rgba(255,138,61,.10));border-bottom:1px solid var(--border);}
-.stm32-hero h2{font-family:'Space Grotesk','Noto Sans SC',sans-serif;font-size:1.35em;letter-spacing:.02em;margin-bottom:6px;}
-.stm32-hero p{font-size:.86em;color:var(--muted);line-height:1.7;}
-.stm32-steps{display:grid;grid-template-columns:1fr;gap:8px;}
-.stm32-step{background:var(--surface2);border:1px solid var(--border);border-radius:8px;padding:9px 10px;font-size:.8em;line-height:1.6;}
-.stm32-step b{color:var(--text);}
+#page-stm32 .workspace{display:grid;grid-template-columns:1.1fr .9fr;gap:var(--space-3);padding:var(--space-3);flex:1;align-items:start;}
+.stm32-hero{padding:var(--space-4) var(--space-4);background:var(--color-surface);border-bottom:1px solid var(--color-border);}
+.stm32-hero h2{font-family:'Space Grotesk','Noto Sans SC',sans-serif;font-size:var(--text-lg);letter-spacing:0;margin-bottom:var(--space-2);font-weight:600;color:var(--color-primary);}
+.stm32-hero p{font-size:var(--text-sm);color:var(--color-secondary);line-height:1.5;}
+.stm32-steps{display:grid;grid-template-columns:1fr;gap:var(--space-2);}
+.stm32-step{background:var(--color-surface);border:1px solid var(--color-border);border-radius:var(--radius);padding:var(--space-2) var(--space-3);font-size:var(--text-sm);line-height:1.5;}
+.stm32-step b{color:var(--color-primary);}
 
 @media (max-width: 1180px){
   #page-camera .workspace{grid-template-columns:1fr;}
@@ -327,10 +344,10 @@ select option{background:var(--surface);}
 }
 
 @media (max-width: 820px){
-  .topbar{height:auto;flex-wrap:wrap;padding:8px 10px;gap:8px;}
-  .logo{border-right:none;padding-right:8px;}
+  .topbar{height:auto;flex-wrap:wrap;padding:var(--space-2) var(--space-3);gap:var(--space-2);}
+  .logo{border-right:none;padding-right:var(--space-2);}
   .tabs{order:3;flex:1 0 100%;padding-left:0;overflow-x:auto;}
-  .tab-btn{height:42px;white-space:nowrap;padding:0 14px;}
+  .tab-btn{height:42px;white-space:nowrap;padding:0 var(--space-3);}
   .topbar-right{margin-left:0;width:100%;justify-content:flex-end;}
 }
 </style>
@@ -831,12 +848,13 @@ select option{background:var(--surface);}
           <div style="display:grid;grid-template-columns:1fr;gap:6px;flex:1;font-size:.78em;color:var(--muted);">
             <label><input type="checkbox" id="rosAutomationEnabled" onchange="applyRosConfig(true)"> 启用 YOLO 快照轮询</label>
             <label><input type="checkbox" id="rosForwardEnabled" onchange="applyRosConfig(false)" checked> 识别 forward -> ROS 前进</label>
+            <label><input type="checkbox" id="rosBackwardEnabled" onchange="applyRosConfig(false)" checked> 识别 backward -> ROS 后退</label>
             <label><input type="checkbox" id="rosStopEnabled" onchange="applyRosConfig(false)" checked> 识别 stop -> ROS 停车</label>
             <label><input type="checkbox" id="rosObstacleEnabled" onchange="applyRosConfig(false)" checked> 识别 obstacle_box -> multi_avoidance</label>
           </div>
         </div>
         <div class="form-row">
-          <label>前进</label>
+          <label>线速度</label>
           <input type="number" id="rosForwardLinear" value="0.18" min="0.01" max="1.50" step="0.01">
         </div>
         <div class="form-row">
@@ -857,7 +875,22 @@ select option{background:var(--surface);}
         <div class="state-line">避障节点：<b id="rosAvoidState">未运行</b></div>
         <div class="state-line">视觉动作：<b id="rosActionSummary">idle</b></div>
         <div class="state-line">最近快照：<b id="rosDetectSummary">尚未执行</b></div>
-        <div class="mini-note" style="margin-top:8px;">这里复用 src/ros2_ws 中的 wheeltec_robot_node 与 multi_avoidance。obstacle_box 会被映射成 object_tracker/current_position 话题输入。</div>
+        <div class="mini-note" style="margin-top:8px;margin-bottom:8px;">这里复用 src/ros2_ws 中的 wheeltec_robot_node 与 multi_avoidance。obstacle_box 会被映射成 object_tracker/current_position 话题输入。</div>
+        
+        <!-- A1 摄像头端 OSD 预览 -->
+        <div class="divider"></div>
+        <div class="form-row" style="margin-bottom:6px;">
+          <label style="font-weight:600;color:var(--text);">A1 监控</label>
+          <label style="font-size:.78em;color:var(--muted);"><input type="checkbox" id="enableA1Webcam" onchange="toggleA1Webcam(this.checked)" checked> 开启画面流</label>
+        </div>
+        <div style="width:100%;aspect-ratio:16/9;background:#000;border-radius:4px;overflow:hidden;position:relative;">
+          <img id="a1FeedPreview" src="/video_feed" style="width:100%;height:100%;object-fit:contain;" alt="A1 Camera Feed" onerror="this.style.display='none';document.getElementById('a1FeedErr').style.display='flex';" onload="this.style.display='block';document.getElementById('a1FeedErr').style.display='none';">
+          <div id="a1FeedErr" style="display:none;position:absolute;inset:0;align-items:center;justify-content:center;color:#666;font-size:0.8em;">未拉取到视频流</div>
+        </div>
+        <div style="display:grid;grid-template-columns:1fr 1fr;gap:6px;margin-top:8px;">
+          <div class="mini-note" style="text-align:center;padding:4px;" id="gestureForwardState">前进指令：<b style="color:var(--muted);">未检出</b></div>
+          <div class="mini-note" style="text-align:center;padding:4px;" id="gestureBackwardState">后退指令：<b style="color:var(--muted);">未检出</b></div>
+        </div>
       </div>
     </div>
 
@@ -2030,6 +2063,7 @@ function hydrateRosConfig(config, force = false) {
   document.getElementById('rosCameraFov').value = config.camera_hfov_deg || document.getElementById('rosCameraFov').value;
   document.getElementById('rosAutomationEnabled').checked = !!config.automation_enabled;
   document.getElementById('rosForwardEnabled').checked = config.forward_enabled !== false;
+  document.getElementById('rosBackwardEnabled').checked = config.backward_enabled !== false;
   document.getElementById('rosStopEnabled').checked = config.stop_enabled !== false;
   document.getElementById('rosObstacleEnabled').checked = config.obstacle_enabled !== false;
   rosConfigInitialized = true;
@@ -2041,9 +2075,11 @@ function collectRosConfig() {
     serial_port: document.getElementById('rosPortInput').value.trim(),
     serial_baud: parseInt(document.getElementById('rosBaudInput').value || '115200', 10),
     forward_linear_x: parseFloat(document.getElementById('rosForwardLinear').value || '0.18'),
+    backward_linear_x: -0.18,
     camera_hfov_deg: parseFloat(document.getElementById('rosCameraFov').value || '60'),
     automation_enabled: document.getElementById('rosAutomationEnabled').checked,
     forward_enabled: document.getElementById('rosForwardEnabled').checked,
+    backward_enabled: document.getElementById('rosBackwardEnabled').checked,
     stop_enabled: document.getElementById('rosStopEnabled').checked,
     obstacle_enabled: document.getElementById('rosObstacleEnabled').checked,
   };
@@ -2179,6 +2215,39 @@ function updateRosSnapshotView(data) {
   if (ros.action) text += ` | action=${ros.action}`;
   document.getElementById('rosDetectSummary').textContent = text;
   if (ros.reason) document.getElementById('rosActionSummary').textContent = `${ros.action || 'idle'} · ${ros.reason}`;
+  
+  // 更新手势监控面板
+  const fwdCount = counts['forward'] || 0;
+  const bwdCount = counts['backward'] || 0;
+  
+  const fwdState = document.getElementById('gestureForwardState');
+  if (fwdCount > 0) {
+    fwdState.innerHTML = `前进指令：<b style="color:var(--primary);">已检出(${fwdCount})</b>`;
+  } else {
+    fwdState.innerHTML = `前进指令：<b style="color:var(--muted);">未检出</b>`;
+  }
+  
+  const bwdState = document.getElementById('gestureBackwardState');
+  if (bwdCount > 0) {
+    bwdState.innerHTML = `后退指令：<b style="color:var(--amber);">已检出(${bwdCount})</b>`;
+  } else {
+    bwdState.innerHTML = `后退指令：<b style="color:var(--muted);">未检出</b>`;
+  }
+}
+
+function toggleA1Webcam(enabled) {
+  const imgEL = document.getElementById('a1FeedPreview');
+  const errEL = document.getElementById('a1FeedErr');
+  if (enabled) {
+    imgEL.src = '/video_feed?' + Date.now();
+    imgEL.style.display = 'block';
+    errEL.style.display = 'none';
+  } else {
+    imgEL.src = '';
+    imgEL.style.display = 'none';
+    errEL.style.display = 'flex';
+    errEL.textContent = '流已暂停';
+  }
 }
 
 function triggerDetectSnapshot(showToast = false) {

--- a/tools/aurora/templates/companion_ui.html
+++ b/tools/aurora/templates/companion_ui.html
@@ -111,27 +111,29 @@ body{
 }
 
 .camera-rail{
-  flex:0 0 400px;
-  max-width:400px;
-  min-height:0;
-  overflow-y:auto;
-  overscroll-behavior:contain;
-  display:flex;
-  flex-direction:column;
-  gap:var(--space-2);
-  padding-right:4px;
+  flex: 1 1 0;
+  min-width: 0;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  display: grid;
+  grid-template-rows: minmax(420px, 2.3fr) minmax(220px, 1fr);
+  align-content: stretch;
+  gap: var(--space-3);
+  padding-right: 4px;
 }
 
 .page-stage{
-  flex:1 1 0;
-  min-width:0;
-  min-height:0;
-  overflow-y:auto;
-  overscroll-behavior:contain;
-  display:flex;
-  flex-direction:column;
-  gap:var(--space-3);
-  padding-right:4px;
+  flex: 0 0 450px;
+  max-width: 450px;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding-right: 4px;
+  padding-left: 8px;
 }
 
 .page-stage > .page.active{
@@ -279,8 +281,13 @@ body{
 }
 .card-body{padding:var(--space-3);}
 
-.preview-wrap{position:relative;background:#000;line-height:0;}
+.preview-wrap{position:relative;background:#000;line-height:0;min-height:280px;}
 .preview-wrap img{width:100%;display:block;}
+.preview-main-card{display:flex;flex-direction:column;min-height:0;}
+.preview-main-card .preview-wrap{flex:1 1 auto;min-height:420px;display:flex;align-items:stretch;}
+.preview-main-card .preview-wrap img{height:100%;object-fit:contain;}
+.gallery-main-card{display:flex;flex-direction:column;min-height:0;}
+.gallery-main-card .card-body{flex:1 1 auto;min-height:0;overflow:auto;}
 .preview-fps{position:absolute;top:var(--space-2);right:var(--space-2);background:rgba(255,255,255,0.9);border:1px solid var(--color-border);border-radius:var(--radius);padding:var(--space-1) var(--space-2);font-size:var(--text-xs);font-family:monospace;color:var(--color-secondary);}
 
 /* 摄像头加载遮罩 */
@@ -345,7 +352,7 @@ body{
 .gallery-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-1);}
 .gallery-item{position:relative;border-radius:var(--radius);overflow:hidden;background:#000;border:1px solid var(--color-border);transition:border-color .15s;cursor:pointer;}
 .gallery-item:hover{border-color:var(--color-brand);}
-.gallery-item img{width:100%;display:block;}
+.gallery-item img{width:100%;display:block;aspect-ratio:16/9;object-fit:cover;}
 .gallery-item .g-lbl{position:absolute;bottom:0;left:0;right:0;background:rgba(255,255,255,.9);font-size:var(--text-xs);color:var(--color-secondary);padding:2px var(--space-1);text-align:center;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
 .gallery-empty{grid-column:1/-1;text-align:center;color:var(--color-secondary);font-size:var(--text-sm);padding:var(--space-3) 0;}
 
@@ -491,8 +498,10 @@ select:focus, input:focus{outline:none;border-color:var(--color-brand);box-shado
 
 @media (max-width: 900px){
   .app-shell{flex-direction:column;overflow:auto;}
-  .camera-rail,.page-stage{max-width:none;overflow:visible;padding-right:0;}
-  .camera-rail{flex-basis:auto;}
+  .camera-rail,.page-stage{flex:0 0 auto;max-width:none;width:100%;padding-right:0;padding-left:0;}
+  .camera-rail{
+    grid-template-rows:minmax(300px, 1.7fr) minmax(180px, 1fr);
+  }
 }
 
 @media (max-width: 820px){
@@ -536,7 +545,7 @@ select:focus, input:focus{outline:none;border-color:var(--color-brand);box-shado
 
 <div class="app-shell">
   <aside class="camera-rail">
-    <div class="card">
+    <div class="card preview-main-card">
       <div class="card-head">
         <span>实时预览</span>
         <div style="display:flex;align-items:center;gap:8px;">
@@ -560,21 +569,20 @@ select:focus, input:focus{outline:none;border-color:var(--color-brand);box-shado
       </div>
     </div>
 
-    <div class="card" id="detInfoPanel" style="display:none;">
-      <div class="card-head">YOLOv8 检测信息</div>
-      <div class="det-panel">
-        <table>
-          <tr><td>模型</td><td><span class="det-badge" id="detModelName">best_a1_formal.onnx</span></td></tr>
-          <tr><td>格式</td><td id="detModelMode">标准输出</td></tr>
-          <tr><td>输入尺寸</td><td>640 × 640 (letterbox)</td></tr>
-          <tr><td>类别数</td><td id="detNumCls">4</td></tr>
-          <tr><td>置信度</td><td id="detConf">≥ 0.40</td></tr>
-          <tr><td>NMS IoU</td><td>0.45</td></tr>
-          <tr><td>运行时</td><td id="detRuntime">—</td></tr>
-        </table>
-        <div id="detWarn" class="det-warn" style="display:none;"></div>
+    <div class="card gallery-main-card">
+      <div class="card-head">
+        <span>最近拍摄</span>
+        <span id="galleryCount" style="color:var(--color-secondary)">0 / 8</span>
+      </div>
+      <div class="card-body">
+        <div class="gallery-grid" id="gallery">
+          <div class="gallery-empty">暂无拍摄记录</div>
+        </div>
       </div>
     </div>
+  </aside>
+
+  <main class="page-stage">
 
     <div class="card">
       <div class="card-head">输入源与采集</div>
@@ -631,15 +639,19 @@ select:focus, input:focus{outline:none;border-color:var(--color-brand);box-shado
       </div>
     </div>
 
-    <div class="card">
-      <div class="card-head">
-        <span>最近拍摄</span>
-        <span id="galleryCount" style="color:var(--color-secondary)">0 / 8</span>
-      </div>
-      <div class="card-body">
-        <div class="gallery-grid" id="gallery">
-          <div class="gallery-empty">暂无拍摄记录</div>
-        </div>
+    <div class="card" id="detInfoPanel" style="display:none;">
+      <div class="card-head">YOLOv8 检测信息</div>
+      <div class="det-panel">
+        <table>
+          <tr><td>模型</td><td><span class="det-badge" id="detModelName">best_a1_formal.onnx</span></td></tr>
+          <tr><td>格式</td><td id="detModelMode">标准输出</td></tr>
+          <tr><td>输入尺寸</td><td>640 × 640 (letterbox)</td></tr>
+          <tr><td>类别数</td><td id="detNumCls">4</td></tr>
+          <tr><td>置信度</td><td id="detConf">≥ 0.40</td></tr>
+          <tr><td>NMS IoU</td><td>0.45</td></tr>
+          <tr><td>运行时</td><td id="detRuntime">—</td></tr>
+        </table>
+        <div id="detWarn" class="det-warn" style="display:none;"></div>
       </div>
     </div>
 
@@ -661,9 +673,6 @@ select:focus, input:focus{outline:none;border-color:var(--color-brand);box-shado
         </div>
       </div>
     </div>
-  </aside>
-
-  <main class="page-stage">
     <div class="page active" id="page-stm32">
       <section class="workflow-hero">
         <div class="workflow-eyebrow">电脑直连工作流</div>


### PR DESCRIPTION
## 概述

本 PR 继续收敛 Aurora Companion 在 Windows + A1 场景下的相机与底盘联调体验，覆盖三块内容：

### 本轮补充（2026-04-22）

1. `tools/aurora/launch.ps1` 统一为 UTF-8 with BOM 保存，修复 Windows PowerShell 启动时中文文案偶发乱码。
2. `tools/aurora/templates/companion_ui.html` 进一步重排为“预览优先”布局：左侧主区突出实时预览 + 最近拍摄，右侧集中输入源/采集/设备信息与底盘工作流。
3. 右侧工具栏滚动容器关系进一步收束，`输入源与采集 / 设备信息 / ROS 直连` 在窄高窗口下可正常滚轮下滑，不再截断。

1. 保留并整合分支上已有的 backward 手势 / ROS 联动改动
2. 缩短 Companion 首次相机加载路径，复用上一次成功的 device/source，并规避 Windows DirectShow 句柄竞争
3. 把原来堆在一个页面里的底盘调试流程拆成「电脑直连」和「经由 A1」两条明确工作流，同时把视频预览固定在左侧，减少来回切换和误操作

## 主要变更

### 1. A1 手势与 ROS 联动

- A1 侧新增 backward 手势类别与后退速度映射
- `tools/aurora/ros_bridge.py` 补齐 backward 动作配置与调度路径
- `tools/aurora/templates/companion_ui.html` 的 ROS 区域增加 backward 开关与前进/后退状态展示

### 2. Companion 相机启动与切换优化

- `tools/aurora/aurora_companion.py`
	- 新增 `.a1_camera_source` 运行时缓存，和已有 `.a1_camera_device` 一起复用上一次成功的 device/source
	- `choose_camera_device()` 在自动模式下优先尝试缓存设备，命中后不再重新全量扫描
	- 显式设备启动时只 probe 指定设备，不再走全扫描路径
	- `probe_camera_device()` 在 `camera_lock` 内完成临时打开、读帧与释放，避免和实时视频流并发抢占 DirectShow 句柄
	- `switch_camera()` 优先读取已有 `camera_devices_snapshot` 判断 source，减少无意义的再次枚举
	- 启动和切换成功后同时保存 preferred device / preferred source

### 3. Companion UI 工作流重构

- `tools/aurora/templates/companion_ui.html`
	- 顶部标签页收敛为两个页面：`电脑直连` / `经由 A1`
	- 删除单独的摄像头页与 `setControlTarget('direct'|'relay')` 手动切换逻辑
	- 重构为「左侧固定预览工作台 + 右侧工作流页面 + 下方共享控制区」
	- 电脑直连页聚焦本机串口连接、联通检查与 ROS 直连调试
	- 经由 A1 页聚焦 Relay 地址、远端串口配置与接线参考
	- 联通测试、遥测、运动控制、原始帧发送、通信日志统一放到共享区，并随当前页面自动切换目标
	- 外层布局从容易在集成浏览器里塌陷的 grid 调整为 flex，桌面宽度下稳定保持双栏，窄屏回落为单列
	- 修复 body / shell / stage 的滚动容器关系，解决左侧相机工作台和主区模块被截断但无法滚轮下滑的问题
	- 接线参考新增 `A1 接法` / `PC 调试接法` 可点击切换，按当前视图过滤对应接线行
	- 清理模板中残留的旧 `page/workspace` 布局样式、无效 DOM 逻辑和旧颜色变量引用

### 4. 启动脚本与运行时清理

- `tools/aurora/launch.ps1`
	- Companion 模式输出文案改为新的工作台结构：左侧预览工作台 / 电脑直连 / 经由 A1
	- 启动提示明确说明会优先复用上一次成功的相机 device/source
- `.gitignore`
	- 忽略 `tools/aurora/.a1_camera_source`，避免运行时缓存进入 PR

## 验证

### 已执行

- IDE / 语法诊断通过：
	- `tools/aurora/aurora_companion.py`
	- `tools/aurora/templates/companion_ui.html`
	- `tools/aurora/launch.ps1`
- Windows 实际启动验证：
	- 执行 `tools/aurora/launch.ps1 -Mode companion -NoBrowser`
	- Companion 成功启动在 `http://127.0.0.1:5801`
	- 自动探测命中 `device 1`，并以缓存 source 完成打开
- 浏览器验收：
	- 桌面宽度下 `.app-shell` 为横向 flex 双栏
	- 左侧固定预览 rail 与右侧页面区几何布局正确
	- 切换到 `经由 A1` 后，共享区目标标签正确变为 `A1 Relay`
	- `.page-stage` 在当前浏览器宽度下可真实滚动，ROS 直连模块与共享区不再被截断
	- 接线参考按钮切换后，可在 `A1 接法` 与 `PC 调试接法` 两种视图之间正确过滤表格行

### 建议回归

- 不同 USB 摄像头组合下的首次启动耗时与缓存命中率
- Windows 下长时间切换 source / device 的稳定性
- PC 直连 STM32 与 PC → A1 → STM32 两条链路的联通测试与遥测回传

## 影响文件

- `tools/aurora/aurora_companion.py`
- `tools/aurora/templates/companion_ui.html`
- `tools/aurora/launch.ps1`
- `.gitignore`
