### PR TITLE
fix: stabilize Aurora Qt bridge startup on Windows

### DIFF
--- a/tools/aurora/aurora_companion.py
+++ b/tools/aurora/aurora_companion.py
@@ -136,6 +136,7 @@ QT_BRIDGE_HOST = "127.0.0.1"
 QT_BRIDGE_URL = f"http://{QT_BRIDGE_HOST}:{QT_BRIDGE_PORT}"
 QT_BRIDGE_PROTOCOL_VERSION = 2
 QT_BRIDGE_OWNER_STATE_FILE = Path(__file__).with_name(".qt_bridge_owner.json")
+AURORA_PYTHON_ENV_VAR = "AURORA_PYTHON"
 CAMERA_SOURCE_WINDOWS = "windows"
 CAMERA_SOURCE_A1 = "a1"
 CAMERA_SOURCE_AUTO = "auto"
@@ -598,21 +599,23 @@ def _python_has_module(python_exe: str, module_name: str) -> bool:
 
 def _select_qt_bridge_python() -> str:
     repo_root = Path(__file__).resolve().parents[2]
-    candidates = [
+    preferred_python = str(os.environ.get(AURORA_PYTHON_ENV_VAR, "")).strip()
+    candidates = []
+    if preferred_python:
+        candidates.append(preferred_python)
+    candidates.extend([
         repo_root / "venv_39" / "Scripts" / "python.exe",
         Path(sys.executable),
-    ]
+    ])
     if sys.platform == "win32":
-        candidates.append(Path("python"))
+        candidates.append("python")
     seen = set()
     for candidate in candidates:
-        key = str(candidate).lower()
+        python_exe = str(candidate)
+        key = python_exe.lower()
         if key in seen:
             continue
         seen.add(key)
-        if str(candidate) != "python" and not candidate.exists():
-            continue
-        python_exe = str(candidate)
         if _python_has_module(python_exe, "PySide6"):
             return python_exe
     return sys.executable
@@ -632,14 +635,6 @@ foreach ($conn in $connections) {{
     if ($cmd -match "qt_camera_bridge\.py") {{
         Write-Host "[Aurora] Terminating stale Qt camera bridge on port {QT_BRIDGE_PORT} (PID $procId)"
         Stop-Process -Id $procId -Force -ErrorAction SilentlyContinue
-    }}
-}}
-$bridgeProcs = Get-CimInstance Win32_Process -Filter "Name='python.exe' OR Name='pythonw.exe'" -ErrorAction SilentlyContinue
-foreach ($proc in $bridgeProcs) {{
-    $cmd = [string]$proc.CommandLine
-    if ($cmd -match "qt_camera_bridge\.py") {{
-        Write-Host "[Aurora] Terminating stale Qt camera bridge process (PID $($proc.ProcessId))"
-        Stop-Process -Id $proc.ProcessId -Force -ErrorAction SilentlyContinue
     }}
 }}
 Start-Sleep -Milliseconds 400

--- a/tools/aurora/launch.ps1
+++ b/tools/aurora/launch.ps1
@@ -21,18 +21,128 @@ function Initialize-Utf8Console {
     $env:no_proxy = $loopbackBypass
 }
 
+function Get-QtBridgeOwnerStatePath {
+    return Join-Path $ScriptDir ".qt_bridge_owner.json"
+}
+
+function Get-RepoVenvRoot {
+    return [System.IO.Path]::GetFullPath((Join-Path $ScriptDir "..\..\venv_39"))
+}
+
+function Get-VenvBasePython {
+    param([string]$VenvRoot)
+
+    $cfgPath = Join-Path $VenvRoot "pyvenv.cfg"
+    if (-not (Test-Path $cfgPath)) {
+        return $null
+    }
+
+    try {
+        $homeLine = Get-Content -Path $cfgPath | Where-Object { $_ -match '^\s*home\s*=' } | Select-Object -First 1
+        if (-not $homeLine) {
+            return $null
+        }
+        $baseHome = ($homeLine -split '=', 2)[1].Trim()
+        if (-not $baseHome) {
+            return $null
+        }
+        $basePython = Join-Path $baseHome "python.exe"
+        if (Test-Path $basePython) {
+            return [System.IO.Path]::GetFullPath($basePython)
+        }
+    } catch {}
+
+    return $null
+}
+
+function Set-AuroraPythonEnvironment {
+    param([string]$PythonExecutable)
+
+    $venvRoot = Get-RepoVenvRoot
+    $cfgPath = Join-Path $venvRoot "pyvenv.cfg"
+    if (-not (Test-Path $cfgPath)) {
+        return
+    }
+
+    $sitePackages = Join-Path $venvRoot "Lib\site-packages"
+    $scriptsDir = Join-Path $venvRoot "Scripts"
+    $pythonDir = Split-Path $PythonExecutable -Parent
+
+    $env:VIRTUAL_ENV = $venvRoot
+    if (Test-Path $sitePackages) {
+        if ([string]::IsNullOrWhiteSpace($env:PYTHONPATH)) {
+            $env:PYTHONPATH = [System.IO.Path]::GetFullPath($sitePackages)
+        } else {
+            $env:PYTHONPATH = ([System.IO.Path]::GetFullPath($sitePackages)) + ";" + $env:PYTHONPATH
+        }
+    }
+
+    $prependPath = @()
+    if (Test-Path $scriptsDir) {
+        $prependPath += [System.IO.Path]::GetFullPath($scriptsDir)
+    }
+    if ($pythonDir) {
+        $prependPath += $pythonDir
+    }
+    if ($prependPath.Count -gt 0) {
+        $env:PATH = ($prependPath -join ";") + ";" + $env:PATH
+    }
+}
+
 function Get-PythonExecutable {
-    $candidates = @(
-        (Join-Path $ScriptDir "..\..\venv_39\Scripts\python.exe"),
-        "python"
-    ) | Where-Object { Test-Path $_ }
+    $venvRoot = Get-RepoVenvRoot
+    $venvPython = Join-Path $venvRoot "Scripts\python.exe"
+    $basePython = Get-VenvBasePython -VenvRoot $venvRoot
+    $candidates = @()
+    if ($basePython) {
+        $candidates += $basePython
+    }
+    if (Test-Path $venvPython) {
+        $candidates += [System.IO.Path]::GetFullPath($venvPython)
+    }
+    $candidates += "python"
+
     foreach ($candidate in $candidates) {
         try {
             $version = & $candidate --version 2>&1
-            if ($version -match "Python 3") { return $candidate }
+            if ($version -match "Python 3") {
+                return $candidate
+            }
         } catch {}
     }
     return "python"
+}
+
+function Stop-OwnedQtBridge {
+    $statePath = Get-QtBridgeOwnerStatePath
+    if (-not (Test-Path $statePath)) {
+        return @()
+    }
+
+    try {
+        $state = Get-Content -Raw -Path $statePath | ConvertFrom-Json
+    } catch {
+        Remove-Item $statePath -Force -ErrorAction SilentlyContinue
+        return @()
+    }
+
+    $ownerPid = 0
+    try { $ownerPid = [int]$state.pid } catch { $ownerPid = 0 }
+    if ($ownerPid -le 0 -or $ownerPid -eq $PID) {
+        Remove-Item $statePath -Force -ErrorAction SilentlyContinue
+        return @()
+    }
+
+    $proc = Get-CimInstance Win32_Process -Filter "ProcessId=$ownerPid" -ErrorAction SilentlyContinue
+    if ($proc -and ([string]$proc.CommandLine) -match "qt_camera_bridge\.py") {
+        Write-Host "[Aurora] Terminating owned Qt camera bridge (PID $ownerPid)"
+        Stop-Process -Id $ownerPid -Force -ErrorAction SilentlyContinue
+        Remove-Item $statePath -Force -ErrorAction SilentlyContinue
+        return @($ownerPid)
+    }
+
+    Remove-Item $statePath -Force -ErrorAction SilentlyContinue
+    return @()
 }
 
 function Start-AuroraBootstrap {
@@ -142,12 +252,12 @@ function Stop-StaleCompanionOnPort {
     try {
         $connections = Get-NetTCPConnection -LocalPort $BindPort -State Listen -ErrorAction SilentlyContinue
         foreach ($conn in $connections) {
-            $pId = [int]$conn.OwningProcess
-            if ($pId -le 0 -or $pId -eq $PID) { continue }
-            $proc = Get-CimInstance Win32_Process -Filter "ProcessId=$pId" -ErrorAction SilentlyContinue
+            $ownerPid = [int]$conn.OwningProcess
+            if ($ownerPid -le 0 -or $ownerPid -eq $PID) { continue }
+            $proc = Get-CimInstance Win32_Process -Filter "ProcessId=$ownerPid" -ErrorAction SilentlyContinue
             if ($proc -and ([string]$proc.CommandLine) -match "aurora_companion\.py") {
-                Write-Host "[Aurora] Releasing stale Companion port $BindPort (PID $pId)"
-                Stop-Process -Id $pId -Force -ErrorAction SilentlyContinue
+                Write-Host "[Aurora] Releasing stale Companion port $BindPort (PID $ownerPid)"
+                Stop-Process -Id $ownerPid -Force -ErrorAction SilentlyContinue
             }
         }
     } catch {}
@@ -155,27 +265,15 @@ function Stop-StaleCompanionOnPort {
 
 function Stop-StaleQtBridge {
     $QtBridgePort = 5911
-    $killedPids = @()
+    $killedPids = @(Stop-OwnedQtBridge)
     try {
         $connections = Get-NetTCPConnection -LocalPort $QtBridgePort -State Listen -ErrorAction SilentlyContinue
         foreach ($conn in $connections) {
             $pId = [int]$conn.OwningProcess
-            if ($pId -le 0 -or $pId -eq $PID) { continue }
+            if ($pId -le 0 -or $pId -eq $PID -or $killedPids -contains $pId) { continue }
             $proc = Get-CimInstance Win32_Process -Filter "ProcessId=$pId" -ErrorAction SilentlyContinue
             if ($proc -and ([string]$proc.CommandLine) -match "qt_camera_bridge\.py") {
                 Write-Host "[Aurora] Terminating stale Qt camera bridge (PID $pId)"
-                Stop-Process -Id $pId -Force -ErrorAction SilentlyContinue
-                $killedPids += $pId
-            }
-        }
-    } catch {}
-    try {
-        $bridgeProcs = Get-CimInstance Win32_Process -Filter "Name='python.exe' OR Name='pythonw.exe'" -ErrorAction SilentlyContinue
-        foreach ($proc in $bridgeProcs) {
-            $pId = [int]$proc.ProcessId
-            if ($pId -le 0 -or $pId -eq $PID -or $killedPids -contains $pId) { continue }
-            if (([string]$proc.CommandLine) -match "qt_camera_bridge\.py") {
-                Write-Host "[Aurora] Terminating stale Qt camera bridge process (PID $pId)"
                 Stop-Process -Id $pId -Force -ErrorAction SilentlyContinue
                 $killedPids += $pId
             }
@@ -219,6 +317,8 @@ $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 Set-Location $ScriptDir
 
 $Python = Get-PythonExecutable
+Set-AuroraPythonEnvironment -PythonExecutable $Python
+$env:AURORA_PYTHON = $Python
 Start-AuroraBootstrap -Disabled:$SkipAurora
 Stop-StaleCompanionOnPort -BindPort $Port
 Stop-StaleQtBridge
@@ -227,4 +327,4 @@ $ResolvedPort = Resolve-AvailablePort -BindHost $ListenHost -PreferredPort $Port
 $browserUrl = "http://127.0.0.1:$ResolvedPort"
 
 Start-BrowserWhenReady -ReadyPort $ResolvedPort -Url $browserUrl
-& $Python aurora_companion.py --device $Device --port $ResolvedPort --host $ListenHost --source $Source
+& $env:AURORA_PYTHON aurora_companion.py --device $Device --port $ResolvedPort --host $ListenHost --source $Source

--- a/tools/aurora/qt_camera_bridge.py
+++ b/tools/aurora/qt_camera_bridge.py
@@ -703,7 +703,10 @@ class BridgeHandler(BaseHTTPRequestHandler):
         self.send_header("Content-Type", "application/json; charset=utf-8")
         self.send_header("Content-Length", str(len(data)))
         self.end_headers()
-        self.wfile.write(data)
+        try:
+            self.wfile.write(data)
+        except (BrokenPipeError, ConnectionAbortedError, ConnectionResetError):
+            return
 
     def _write_bytes(self, payload: bytes, mime: str = "image/jpeg", status: int = 200):
         self.send_response(status)

--- a/tools/aurora/tests/test_aurora_startup.py
+++ b/tools/aurora/tests/test_aurora_startup.py
@@ -139,10 +139,43 @@ class AuroraStartupTests(unittest.TestCase):
 
         self.assertEqual(selected, aurora_companion.sys.executable)
 
+    def test_qt_bridge_python_selector_prefers_launch_env(self):
+        repo_root = Path(aurora_companion.__file__).resolve().parents[2]
+        preferred_python = repo_root / ".venv39" / "Scripts" / "python.exe"
+
+        with mock.patch.dict(aurora_companion.os.environ, {"AURORA_PYTHON": str(preferred_python)}, clear=False), \
+             mock.patch.object(aurora_companion, "_python_has_module", return_value=True) as has_module:
+            selected = aurora_companion._select_qt_bridge_python()
+
+        self.assertEqual(Path(selected), preferred_python)
+        has_module.assert_called_once_with(str(preferred_python), "PySide6")
+
+    def test_launch_script_defines_qt_bridge_owner_state_path_helper(self):
+        launch_script = Path("tools/aurora/launch.ps1").read_text(encoding="utf-8")
+        self.assertIn("function Get-QtBridgeOwnerStatePath", launch_script)
+        self.assertIn('return Join-Path $ScriptDir ".qt_bridge_owner.json"', launch_script)
+
     def test_launch_script_uses_single_repo_python_env(self):
         launch_script = Path("tools/aurora/launch.ps1").read_text(encoding="utf-8")
-        self.assertIn('venv_39\\Scripts\\python.exe', launch_script)
         self.assertNotIn('.venv39\\Scripts\\python.exe', launch_script)
+        self.assertIn('$env:AURORA_PYTHON = $Python', launch_script)
+        self.assertIn('Set-AuroraPythonEnvironment -PythonExecutable $Python', launch_script)
+        self.assertIn('& $env:AURORA_PYTHON aurora_companion.py', launch_script)
+
+    def test_launch_script_uses_base_python_with_venv_packages(self):
+        launch_script = Path("tools/aurora/launch.ps1").read_text(encoding="utf-8")
+        self.assertIn("pyvenv.cfg", launch_script)
+        self.assertIn("$env:VIRTUAL_ENV", launch_script)
+        self.assertIn("$env:PYTHONPATH", launch_script)
+
+    def test_launch_script_companion_cleanup_avoids_pid_variable_collision(self):
+        launch_script = Path("tools/aurora/launch.ps1").read_text(encoding="utf-8")
+        start = launch_script.index("function Stop-StaleCompanionOnPort")
+        end = launch_script.index("function Stop-StaleQtBridge")
+        cleanup_block = launch_script[start:end]
+        self.assertNotIn("$pId = [int]$conn.OwningProcess", cleanup_block)
+        self.assertIn("$ownerPid = [int]$conn.OwningProcess", cleanup_block)
+        self.assertIn("$ownerPid -le 0 -or $ownerPid -eq $PID", cleanup_block)
 
 
 if __name__ == "__main__":

--- a/tools/aurora/tests/test_qt_bridge_lifecycle.py
+++ b/tools/aurora/tests/test_qt_bridge_lifecycle.py
@@ -17,6 +17,7 @@ def _patched_path_exists(self):
 
 with mock.patch("pathlib.Path.exists", new=_patched_path_exists):
     aurora_companion = importlib.import_module("tools.aurora.aurora_companion")
+    qt_camera_bridge = importlib.import_module("tools.aurora.qt_camera_bridge")
 
 
 class QtBridgeLifecycleTests(unittest.TestCase):
@@ -87,6 +88,21 @@ class QtBridgeLifecycleTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.get_json()["success"])
         cleanup_mock.assert_called_once()
+
+
+    def test_bridge_write_json_ignores_client_abort(self):
+        handler = object.__new__(qt_camera_bridge.BridgeHandler)
+        handler.send_response = mock.Mock()
+        handler.send_header = mock.Mock()
+        handler.end_headers = mock.Mock()
+        handler.wfile = mock.Mock()
+        handler.wfile.write.side_effect = ConnectionAbortedError("client disconnected")
+
+        qt_camera_bridge.BridgeHandler._write_json(handler, {"success": False}, status=503)
+
+        handler.send_response.assert_called_once_with(503)
+        handler.end_headers.assert_called_once_with()
+        handler.wfile.write.assert_called_once()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- make Aurora launch choose one Python runtime and pass it through to the Qt bridge
- stop only owned or port-bound Qt bridge processes instead of sweeping unrelated Python processes
- ignore client disconnects during bridge JSON writes and add regression coverage for launch and bridge lifecycle behavior

## Test plan
- [ ] python -m pytest tools/aurora/tests/test_aurora_startup.py -q
- [ ] python -m pytest tools/aurora/tests/test_qt_bridge_lifecycle.py -q

🤖 Generated with [Claude Code](https://claude.com/claude-code)