### PR TITLE
Align A1 camera viewport OSD layout

### DIFF
--- a/data/A1_SDK_SC132GS/smartsens_sdk/smart_software/src/app_demo/face_detection/ssne_ai_demo/demo_face.cpp
+++ b/data/A1_SDK_SC132GS/smartsens_sdk/smart_software/src/app_demo/face_detection/ssne_ai_demo/demo_face.cpp
@@ -304,22 +304,24 @@ bool check_exit_flag() {
     return g_exit_flag;
 }
 
-std::vector<std::array<float, 4>> to_osd_boxes(const FaceDetectionResult& det_result,
-                                               float crop_offset_y,
-                                               float osd_scale_x,
-                                               float osd_scale_y)
+std::vector<std::array<float, 4>> to_osd_boxes(const FaceDetectionResult& det_result)
 {
-    std::vector<std::array<float, 4>> boxes_original_coord;
-    boxes_original_coord.reserve(det_result.boxes.size());
+    constexpr float scale_x = static_cast<float>(cfg::CAMERA_VIEW_WIDTH) /
+                              static_cast<float>(cfg::PIPE_CROP_WIDTH);
+    constexpr float scale_y = static_cast<float>(cfg::CAMERA_VIEW_HEIGHT) /
+                              static_cast<float>(cfg::PIPE_CROP_HEIGHT);
+
+    std::vector<std::array<float, 4>> boxes_in_view;
+    boxes_in_view.reserve(det_result.boxes.size());
     for (const auto& box : det_result.boxes) {
-        boxes_original_coord.push_back({
-            box[0] * osd_scale_x,
-            (box[1] + crop_offset_y) * osd_scale_y,
-            box[2] * osd_scale_x,
-            (box[3] + crop_offset_y) * osd_scale_y,
+        boxes_in_view.push_back({
+            cfg::CAMERA_VIEW_X + box[0] * scale_x,
+            cfg::CAMERA_VIEW_Y + box[1] * scale_y,
+            cfg::CAMERA_VIEW_X + box[2] * scale_x,
+            cfg::CAMERA_VIEW_Y + box[3] * scale_y,
         });
     }
-    return boxes_original_coord;
+    return boxes_in_view;
 }
 
 DetectionSummary summarize_best_detection(const FaceDetectionResult& det_result,
@@ -458,11 +460,6 @@ int main(int argc, char** argv) {
     array<int, 2> img_shape = {img_width, img_height};
     array<int, 2> osd_shape = {cfg::OSD_WIDTH, cfg::OSD_HEIGHT};
     array<int, 2> crop_shape = {cfg::PIPE_CROP_WIDTH, cfg::PIPE_CROP_HEIGHT};
-    const float crop_offset_y = static_cast<float>(cfg::PIPE_CROP_Y1);
-    const float osd_scale_x = static_cast<float>(cfg::OSD_WIDTH) /
-                              static_cast<float>(cfg::SENSOR_WIDTH);
-    const float osd_scale_y = static_cast<float>(cfg::OSD_HEIGHT) /
-                              static_cast<float>(cfg::SENSOR_HEIGHT);
 
     IMAGEPROCESSOR processor;
     processor.Initialize(&img_shape);
@@ -480,6 +477,10 @@ int main(int argc, char** argv) {
 
     cout << "sleep for 0.2 second!" << endl;
     usleep(200000);
+    cout << "[A1] OSD canvas=" << cfg::OSD_WIDTH << "x" << cfg::OSD_HEIGHT
+         << " camera_view=(" << cfg::CAMERA_VIEW_X << "," << cfg::CAMERA_VIEW_Y
+         << "," << cfg::CAMERA_VIEW_WIDTH << "," << cfg::CAMERA_VIEW_HEIGHT << ")"
+         << endl;
     cout << "[A1] draw startup background" << endl;
     visualizer.DrawBitmap("background.ssbmp", "shared_colorLUT.sscl", 0, 0, 2);
     cout << "[A1] startup background draw call returned" << endl;
@@ -499,7 +500,7 @@ int main(int argc, char** argv) {
         detector.Predict(&img_sensor, det_result, cfg::DET_CONF_THRESH);
 
         if (!det_result->boxes.empty()) {
-            visualizer.Draw(to_osd_boxes(*det_result, crop_offset_y, osd_scale_x, osd_scale_y));
+            visualizer.Draw(to_osd_boxes(*det_result));
         } else {
             std::vector<std::array<float, 4>> empty_boxes;
             visualizer.Draw(empty_boxes);

--- a/data/A1_SDK_SC132GS/smartsens_sdk/smart_software/src/app_demo/face_detection/ssne_ai_demo/project_paths.hpp
+++ b/data/A1_SDK_SC132GS/smartsens_sdk/smart_software/src/app_demo/face_detection/ssne_ai_demo/project_paths.hpp
@@ -2,9 +2,10 @@
  * project_paths.hpp — ssne_ai_demo 全局配置
  *
  * 分辨率设计说明:
- *   - 显示输出:   1920 × 1080 (YUV422, 与 demo-rps 一致)
- *   - 推理输入:   640 × 480 (RunAiPreprocessPipe 将显示帧缩放到模型输入)
- *   评委演示版本统一沿用 640×480 中心裁剪链路，训练/验证/部署需保持一致。
+ *   - OSD 画布: 1920 × 1080，背景和右侧动画使用全画布绝对坐标
+ *   - 摄像头源: 720 × 1280，取中心 360 × 640 作为左侧视频窗口
+ *   - 摄像头窗口: OSD 坐标 (150, 220)，尺寸 360 × 640
+ *   - 推理输入: 640 × 480，RunAiPreprocessPipe 将摄像头窗口缩放到模型输入
  *
  * 模型说明:
  *   - 当前板端默认使用 YOLOv8 灰度 4 类模型
@@ -19,21 +20,29 @@
 
 namespace cfg {
 
-// ─── 摄像头采集分辨率 ────────────────────────────────────────────────────────
-constexpr int SENSOR_WIDTH  = 1920;
-constexpr int SENSOR_HEIGHT = 1080;
+// ─── 摄像头源分辨率 ────────────────────────────────────────────────────────
+constexpr int SENSOR_WIDTH  = 720;
+constexpr int SENSOR_HEIGHT = 1280;
 
 // ─── OSD 显示画布 ────────────────────────────────────────────────────────────
 constexpr int OSD_WIDTH  = 1920;
 constexpr int OSD_HEIGHT = 1080;
 
-// ─── 在线裁剪区域 ────────────────────────────────────────────────────────────
-constexpr int PIPE_CROP_X1 = 0;
-constexpr int PIPE_CROP_X2 = 720;
-constexpr int PIPE_CROP_Y1 = 370;
-constexpr int PIPE_CROP_Y2 = 910;
-constexpr int PIPE_CROP_WIDTH  = PIPE_CROP_X2 - PIPE_CROP_X1;
-constexpr int PIPE_CROP_HEIGHT = PIPE_CROP_Y2 - PIPE_CROP_Y1;
+// ─── 摄像头视频窗口：中心裁剪后贴到背景左侧 ───────────────────────────────────
+constexpr int CAMERA_VIEW_X = 150;
+constexpr int CAMERA_VIEW_WIDTH = 360;
+constexpr int CAMERA_VIEW_HEIGHT = 640;
+constexpr int CAMERA_VIEW_Y = (OSD_HEIGHT - CAMERA_VIEW_HEIGHT) / 2;
+constexpr int CAMERA_VIEW_RIGHT = CAMERA_VIEW_X + CAMERA_VIEW_WIDTH;
+constexpr int CAMERA_VIEW_BOTTOM = CAMERA_VIEW_Y + CAMERA_VIEW_HEIGHT;
+
+// ─── 在线裁剪区域：720×1280 源图中心 360×640 ────────────────────────────────
+constexpr int PIPE_CROP_WIDTH  = CAMERA_VIEW_WIDTH;
+constexpr int PIPE_CROP_HEIGHT = CAMERA_VIEW_HEIGHT;
+constexpr int PIPE_CROP_X1 = (SENSOR_WIDTH - PIPE_CROP_WIDTH) / 2;
+constexpr int PIPE_CROP_X2 = PIPE_CROP_X1 + PIPE_CROP_WIDTH;
+constexpr int PIPE_CROP_Y1 = (SENSOR_HEIGHT - PIPE_CROP_HEIGHT) / 2;
+constexpr int PIPE_CROP_Y2 = PIPE_CROP_Y1 + PIPE_CROP_HEIGHT;
 
 // ─── 推理后端选择 ────────────────────────────────────────────────────────────
 constexpr bool USE_SCRFD_BACKEND = false;

--- a/data/A1_SDK_SC132GS/smartsens_sdk/smart_software/src/app_demo/face_detection/ssne_ai_demo/src/pipeline_image.cpp
+++ b/data/A1_SDK_SC132GS/smartsens_sdk/smart_software/src/app_demo/face_detection/ssne_ai_demo/src/pipeline_image.cpp
@@ -14,19 +14,60 @@
  * @param in_img_shape 输入图像尺寸 [宽度, 高度]
  * @param in_scale Binning降采样倍数（保留参数以兼容接口，但不使用）
  */
-// void IMAGEPROCESSOR::Initialize(std::array<int, 2>* in_img_shape, 
+// void IMAGEPROCESSOR::Initialize(std::array<int, 2>* in_img_shape,
 //   BinningRatioType in_scale) {
-void IMAGEPROCESSOR::Initialize(std::array<int, 2>* in_img_shape) 
+void IMAGEPROCESSOR::Initialize(std::array<int, 2>* in_img_shape)
 {
     img_shape = *in_img_shape;      // 保存原始图像尺寸
-    
-    // 在线图像配置参数
-    uint16_t img_width = static_cast<uint16_t>(img_shape[0]);
-    uint16_t img_height = static_cast<uint16_t>(img_shape[1]);
-    format_online = SSNE_YUV422_16;
 
-    OnlineSetOutputImage(kPipeline0, format_online, img_width, img_height);
-    
+    // 在线图像配置参数
+    uint16_t img_width = static_cast<uint16_t>(cfg::PIPE_CROP_WIDTH);
+    uint16_t img_height = static_cast<uint16_t>(cfg::PIPE_CROP_HEIGHT);
+    format_online = SSNE_Y_8;
+
+    int crop_ret = OnlineSetCrop(kPipeline0,
+                                 static_cast<uint16_t>(cfg::PIPE_CROP_X1),
+                                 static_cast<uint16_t>(cfg::PIPE_CROP_X2),
+                                 static_cast<uint16_t>(cfg::PIPE_CROP_Y1),
+                                 static_cast<uint16_t>(cfg::PIPE_CROP_Y2));
+    if (crop_ret != 0) {
+        printf("[ERROR] OnlineSetCrop failed ret=%d crop=(%d,%d)-(%d,%d)\n",
+               crop_ret,
+               cfg::PIPE_CROP_X1,
+               cfg::PIPE_CROP_Y1,
+               cfg::PIPE_CROP_X2,
+               cfg::PIPE_CROP_Y2);
+        return;
+    }
+
+    int output_ret = OnlineSetOutputImage(kPipeline0, format_online, img_width, img_height);
+    if (output_ret != 0) {
+        printf("[ERROR] OnlineSetOutputImage failed ret=%d size=%dx%d\n",
+               output_ret,
+               img_width,
+               img_height);
+        return;
+    }
+
+    int update_ret = UpdateOnlineParam();
+    if (update_ret != 0) {
+        printf("[ERROR] UpdateOnlineParam failed ret=%d\n", update_ret);
+        return;
+    }
+
+    printf("[IMAGEPROCESSOR] online crop source=%dx%d crop=(%d,%d)-(%d,%d) output=%dx%d view=(%d,%d,%d,%d)\n",
+           cfg::SENSOR_WIDTH,
+           cfg::SENSOR_HEIGHT,
+           cfg::PIPE_CROP_X1,
+           cfg::PIPE_CROP_Y1,
+           cfg::PIPE_CROP_X2,
+           cfg::PIPE_CROP_Y2,
+           img_width,
+           img_height,
+           cfg::CAMERA_VIEW_X,
+           cfg::CAMERA_VIEW_Y,
+           cfg::CAMERA_VIEW_WIDTH,
+           cfg::CAMERA_VIEW_HEIGHT);
     // 打开pipe0（裁剪图像通道）
     int res0 = OpenOnlinePipeline(kPipeline0);
     if (res0 != 0) {
@@ -38,18 +79,18 @@ void IMAGEPROCESSOR::Initialize(std::array<int, 2>* in_img_shape)
 }
 
 /**
- * @brief 从pipeline获取 1920×1080 图像
- * @param img_sensor 输出参数：存储从pipe0获取的显示图像
+ * @brief 从pipeline获取中心裁剪后的 360×640 摄像头窗口图像
+ * @param img_sensor 输出参数：存储从pipe0获取的显示/推理图像
  */
 void IMAGEPROCESSOR::GetImage(ssne_tensor_t* img_sensor) {
     int capture_code = -1;  // pipe0采集返回码
 
-    // 从pipe0获取 1920×1080 在线图像数据
+    // 从pipe0获取 360×640 在线图像数据
     capture_code = GetImageData(img_sensor, kPipeline0, kSensor0, 0);
-    
+
     // 检查pipe0采集是否成功
     if (capture_code != 0)
-    {   
+    {
         printf("[IMAGEPROCESSOR] Get Invalid Image from kPipeline0!\n");
     }
 }


### PR DESCRIPTION
## Summary
- Add explicit A1 camera viewport constants for a 360x640 crop at OSD position (150,220).
- Configure the online camera pipeline to output the centered viewport crop while keeping Y8 preprocessing.
- Map YOLO boxes into the camera viewport and keep full-canvas OSD background/semantic animations.

## Test plan
- [x] `docker exec A1_Builder bash -lc "cd /app/data/A1_SDK_SC132GS/smartsens_sdk && rm -rf output/build/ssne_ai_demo/ && make BR2_EXTERNAL=./smart_software ssne_ai_demo"`
- [x] `docker exec A1_Builder bash -lc "cd /app/data/A1_SDK_SC132GS/smartsens_sdk && bash /app/scripts/build_complete_evb.sh --app-only"`
- [x] Verified artifacts: `/app/output/evb/20260501_113907/zImage.smartsens-m1-evb` and `ssne_ai_demo`

🤖 Generated with [Claude Code](https://claude.com/claude-code)