### PR TITLE
Add grayscale 5-class training flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,6 @@ build/
 tools/test_yolo/
 
 # Local SDK / datasets / caches
-data/A1_SDK_SC132GS/
 data/A1_SDK_SC132GS/smartsens_sdk/output/
 data/data
 data/yolov8_dataset/

--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,19 @@ build/
 tools/test_yolo/
 
 # Local SDK / datasets / caches
-data/A1_SDK_SC132GS/smartsens_sdk/output/
+data/A1_SDK_SC132GS/*
+!data/A1_SDK_SC132GS/smartsens_sdk/
+data/A1_SDK_SC132GS/smartsens_sdk/*
+!data/A1_SDK_SC132GS/smartsens_sdk/smart_software/
+data/A1_SDK_SC132GS/smartsens_sdk/smart_software/*
+!data/A1_SDK_SC132GS/smartsens_sdk/smart_software/src/
+data/A1_SDK_SC132GS/smartsens_sdk/smart_software/src/*
+!data/A1_SDK_SC132GS/smartsens_sdk/smart_software/src/app_demo/
+data/A1_SDK_SC132GS/smartsens_sdk/smart_software/src/app_demo/*
+!data/A1_SDK_SC132GS/smartsens_sdk/smart_software/src/app_demo/face_detection/
+data/A1_SDK_SC132GS/smartsens_sdk/smart_software/src/app_demo/face_detection/*
+!data/A1_SDK_SC132GS/smartsens_sdk/smart_software/src/app_demo/face_detection/ssne_ai_demo/
+!data/A1_SDK_SC132GS/smartsens_sdk/smart_software/src/app_demo/face_detection/ssne_ai_demo/**
 data/data
 data/yolov8_dataset/
 x3_src_250401/

--- a/.gitignore
+++ b/.gitignore
@@ -21,9 +21,17 @@ build/
 tools/test_yolo/
 
 # Local SDK / datasets / caches
-data/
+data/A1_SDK_SC132GS/
+data/A1_SDK_SC132GS/smartsens_sdk/output/
+data/data
+data/yolov8_dataset/
 x3_src_250401/
-demo-rps/
+demo-rps/dataprocess_modeltrain/__pycache__/
+demo-rps/dataprocess_modeltrain/outputs/
+demo-rps/dataprocess_modeltrain/runs/
+demo-rps/dataprocess_modeltrain/*.onnx
+demo-rps/dataprocess_modeltrain/*.pt
+demo-rps/dataprocess_modeltrain/*.json
 models/
 CLIProxyAPI_6.9.40_windows_amd64/
 

--- a/data/A1_SDK_SC132GS/smartsens_sdk/smart_software/src/app_demo/face_detection/ssne_ai_demo/demo_rps_game.cpp
+++ b/data/A1_SDK_SC132GS/smartsens_sdk/smart_software/src/app_demo/face_detection/ssne_ai_demo/demo_rps_game.cpp
@@ -22,9 +22,9 @@ constexpr int kCameraWidth = 720;
 constexpr int kCameraHeight = 1280;
 constexpr int kClassifierInputWidth = 320;
 constexpr int kClassifierInputHeight = 320;
-constexpr int kClassCount = 5;
+constexpr int kClassCount = 3;
 constexpr int16_t kForwardVelocity = 200;
-constexpr const char* kLabels[kClassCount] = {"person", "stop", "forward", "obstacle", "NoTarget"};
+constexpr const char* kLabels[kClassCount] = {"P", "R", "S"};
 
 volatile sig_atomic_t g_exit_flag = 0;
 ChassisController* g_chassis = nullptr;
@@ -37,7 +37,7 @@ struct LatestRpsSnapshot {
     std::string request_id;
     std::string label = "NoTarget";
     float confidence = 0.0f;
-    float scores[kClassCount] = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+    float scores[kClassCount] = {0.0f, 0.0f, 0.0f};
     std::string action = "stop";
 };
 
@@ -61,8 +61,7 @@ std::string json_escape(const std::string& value) {
 }
 
 std::string action_for_label(const std::string& label) {
-    if (label == "forward") return "forward";
-    return "stop";
+    return label == "P" ? "forward" : "stop";
 }
 
 int16_t vx_for_action(const std::string& action) {
@@ -112,8 +111,7 @@ std::string build_rps_snapshot_json() {
          << ",\"roi\":{\"x\":200,\"y\":480,\"w\":320,\"h\":320}"
          << ",\"label\":\"" << json_escape(snapshot.label) << "\""
          << ",\"confidence\":" << snapshot.confidence
-         << ",\"scores\":[" << snapshot.scores[0] << "," << snapshot.scores[1] << "," << snapshot.scores[2]
-         << "," << snapshot.scores[3] << "," << snapshot.scores[4] << "]"
+         << ",\"scores\":[" << snapshot.scores[0] << "," << snapshot.scores[1] << "," << snapshot.scores[2] << "]"
          << ",\"action\":\"" << json_escape(snapshot.action) << "\""
          << ",\"message\":\"latest classification snapshot\"";
     return body.str();
@@ -277,7 +275,7 @@ int main() {
 
         std::string label;
         float confidence = 0.0f;
-        float scores[kClassCount] = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+        float scores[kClassCount] = {0.0f, 0.0f, 0.0f};
         classifier.Predict(&img_sensor, label, confidence, scores);
         const std::string action = action_for_label(label);
 
@@ -287,11 +285,11 @@ int main() {
         const auto now = std::chrono::steady_clock::now();
         if (now - last_summary_log >= std::chrono::seconds(2)) {
             const uint64_t frames_since_summary = frame_index - last_summary_frame;
-            printf("[RPS] frame=%llu frames_2s=%llu label=%s conf=%.3f scores=[%.3f,%.3f,%.3f,%.3f,%.3f] action=%s\n",
+            printf("[RPS] frame=%llu frames_2s=%llu label=%s conf=%.3f scores=[%.3f,%.3f,%.3f] action=%s\n",
                    static_cast<unsigned long long>(frame_index),
                    static_cast<unsigned long long>(frames_since_summary),
                    label.c_str(), confidence,
-                   scores[0], scores[1], scores[2], scores[3], scores[4], action.c_str());
+                   scores[0], scores[1], scores[2], action.c_str());
             last_summary_frame = frame_index;
             last_summary_log = now;
         }

--- a/data/A1_SDK_SC132GS/smartsens_sdk/smart_software/src/app_demo/face_detection/ssne_ai_demo/include/rps_classifier.hpp
+++ b/data/A1_SDK_SC132GS/smartsens_sdk/smart_software/src/app_demo/face_detection/ssne_ai_demo/include/rps_classifier.hpp
@@ -1,6 +1,6 @@
 /*
  * @Filename: rps_classifier.hpp
- * @Description: 5-class single-label classifier wrapper
+ * @Description: RPS classifier wrapper
  */
 #pragma once
 
@@ -14,7 +14,7 @@ class RPS_CLASSIFIER {
                     std::array<int, 2>* in_cls_shape);
 
     void Predict(ssne_tensor_t* img_in, std::string& out_label, float& out_score,
-                 float out_scores[5] = nullptr);
+                 float out_scores[3] = nullptr);
 
     void Release();
 

--- a/data/A1_SDK_SC132GS/smartsens_sdk/smart_software/src/app_demo/face_detection/ssne_ai_demo/src/rps_classifier.cpp
+++ b/data/A1_SDK_SC132GS/smartsens_sdk/smart_software/src/app_demo/face_detection/ssne_ai_demo/src/rps_classifier.cpp
@@ -1,6 +1,6 @@
 /*
  * @Filename: rps_classifier.cpp
- * @Description: 5-class single-label classifier implementation
+ * @Description: RPS classifier implementation
  */
 #include "../include/rps_classifier.hpp"
 #include "../include/utils.hpp"
@@ -9,8 +9,9 @@
 #include <cstdio>
 
 namespace {
-constexpr const char* kLabels[] = {"person", "stop", "forward", "obstacle", "NoTarget"};
-constexpr int kNumClasses = 5;
+constexpr const char* kLabels[] = {"P", "R", "S"};
+constexpr int kNumClasses = 3;
+constexpr float kNoTargetThreshold = 0.6f;
 }
 
 bool RPS_CLASSIFIER::Initialize(std::string& model_path, std::array<int, 2>* in_img_shape,
@@ -42,11 +43,11 @@ bool RPS_CLASSIFIER::Initialize(std::string& model_path, std::array<int, 2>* in_
     return true;
 }
 
-void RPS_CLASSIFIER::Predict(ssne_tensor_t* img, std::string& out_label, float& out_score, float out_scores[5]) {
+void RPS_CLASSIFIER::Predict(ssne_tensor_t* img, std::string& out_label, float& out_score, float out_scores[3]) {
     const int preprocess_ret = RunAiPreprocessPipe(pipe_offline, *img, inputs[0]);
     if (preprocess_ret != 0) {
         printf("[ERROR] classifier preprocess failed ret=%d\n", preprocess_ret);
-        out_label = "Error";
+        out_label = "NoTarget";
         out_score = 0.0f;
         if (out_scores) {
             for (int i = 0; i < kNumClasses; ++i) out_scores[i] = 0.0f;
@@ -60,7 +61,7 @@ void RPS_CLASSIFIER::Predict(ssne_tensor_t* img, std::string& out_label, float& 
 
     if (ssne_inference(model_id, 1, inputs)) {
         fprintf(stderr, "[ERROR] classifier inference failed\n");
-        out_label = "Error";
+        out_label = "NoTarget";
         out_score = 0.0f;
         if (out_scores) {
             for (int i = 0; i < kNumClasses; ++i) out_scores[i] = 0.0f;
@@ -71,7 +72,7 @@ void RPS_CLASSIFIER::Predict(ssne_tensor_t* img, std::string& out_label, float& 
     ssne_getoutput(model_id, 1, outputs);
     float* data = static_cast<float*>(get_data(outputs[0]));
 
-    float scores[kNumClasses] = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+    float scores[kNumClasses] = {0.0f, 0.0f, 0.0f};
     for (int i = 0; i < kNumClasses; ++i) {
         scores[i] = data[i];
     }
@@ -91,7 +92,7 @@ void RPS_CLASSIFIER::Predict(ssne_tensor_t* img, std::string& out_label, float& 
     }
 
     out_score = max_score;
-    out_label = kLabels[max_idx];
+    out_label = max_score >= kNoTargetThreshold ? kLabels[max_idx] : "NoTarget";
 }
 
 void RPS_CLASSIFIER::Release() {

--- a/demo-rps/dataprocess_modeltrain/README.md
+++ b/demo-rps/dataprocess_modeltrain/README.md
@@ -1,0 +1,90 @@
+# A1 Gray 5-Class Classifier
+
+基于 MobileNetV1 的灰度五分类训练集制作与训练流程，支持 `person`、`stop`、`forward`、`obstacle`、`NoTarget` 五类。
+
+## 依赖安装
+
+```bash
+pip install -r requirements.txt
+```
+
+## 项目结构
+
+```
+.
+├── train_a1_5class_classifier.py   # 5 类训练脚本
+├── prepare_video_dataset.py        # 视频转灰度图片数据集
+├── generate_negative_dataset.py    # 采样 NoTarget 负样本
+├── requirements.txt                # Python 依赖
+└── outputs/                        # 训练输出目录
+```
+
+## 数据集目录
+
+### 输入视频目录
+
+```
+datasets/
+├── person/
+├── stop/
+├── forward/
+├── obstacle/
+└── NoTarget/
+```
+
+### 输出图片目录
+
+```
+processed_dataset/
+├── train/
+│   ├── person/
+│   ├── stop/
+│   ├── forward/
+│   ├── obstacle/
+│   └── NoTarget/
+├── val/
+│   └── <class>/
+└── test/
+    └── <class>/
+```
+
+## 制作训练集
+
+### 1. 视频转灰度图片
+
+```bash
+python prepare_video_dataset.py \
+    --dataset_dir /path/to/video/datasets \
+    --output_dir /path/to/processed_dataset \
+    --crop 210 270 750 810 \
+    --frame_step 3
+```
+
+说明：
+- 输入视频已是灰度也可以直接用
+- 脚本会把裁剪结果按灰度保存
+- 默认按视频数切分 train/val/test
+
+### 2. 训练 5 类模型
+
+```bash
+python train_a1_5class_classifier.py \
+    --dataset_dir /path/to/processed_dataset \
+    --output_dir outputs/a1_5class_mobilenetv1 \
+    --epochs 30 \
+    --batch_size 64 \
+    --lr 1e-3
+```
+
+模型配置：
+- 输入：`1 x 1 x 320 x 320` 灰度张量
+- 输出：`5` 类 logits
+- 损失：`CrossEntropyLoss`
+- 预训练：默认关闭
+
+## 输出
+
+- `best.pt`
+- `last.pt`
+- `metadata.json`
+- 可选 `best.onnx`

--- a/demo-rps/dataprocess_modeltrain/export_onnx.py
+++ b/demo-rps/dataprocess_modeltrain/export_onnx.py
@@ -1,0 +1,175 @@
+import argparse
+import json
+from pathlib import Path
+
+import onnx
+import timm
+import torch
+from torch import nn
+
+MODEL_IMAGE_SIZE = 320
+
+
+class RPSClassifier(nn.Module):
+    def __init__(self, image_size: int, head_hidden_dim: int, dropout: float):
+        super().__init__()
+        self.backbone = timm.create_model(
+            "mobilenetv1_100",
+            pretrained=False,
+            num_classes=0,
+            global_pool="",
+        )
+        feature_channels, feature_height, feature_width = self._infer_feature_shape(
+            image_size
+        )
+        self.head = nn.Sequential(
+            nn.Conv2d(feature_channels, head_hidden_dim, kernel_size=1, bias=False),
+            nn.BatchNorm2d(head_hidden_dim),
+            nn.ReLU(inplace=True),
+            nn.Dropout2d(p=dropout),
+            nn.Conv2d(
+                head_hidden_dim,
+                3,
+                kernel_size=(feature_height, feature_width),
+                bias=True,
+            ),
+            nn.Flatten(1),
+        )
+
+    def _infer_feature_shape(self, image_size: int):
+        was_training = self.backbone.training
+        self.backbone.eval()
+        with torch.no_grad():
+            dummy = torch.zeros(1, 3, image_size, image_size)
+            features = self.backbone(dummy)
+        if was_training:
+            self.backbone.train()
+        return features.shape[1], features.shape[2], features.shape[3]
+
+    def forward(self, x):
+        features = self.backbone(x)
+        logits = self.head(features)
+        return logits
+
+
+class RPSOnnxWrapper(nn.Module):
+    def __init__(self, model: nn.Module):
+        super().__init__()
+        self.model = model
+
+    def forward(self, x):
+        logits = self.model(x)
+        return torch.sigmoid(logits)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Export fixed-shape RPS classifier to ONNX"
+    )
+    parser.add_argument(
+        "--checkpoint",
+        type=str,
+        default="outputs/rps_mobilenetv1/best.pt",
+        help="Path to PyTorch checkpoint",
+    )
+    parser.add_argument(
+        "--output_path",
+        type=str,
+        default="outputs/rps_mobilenetv1/best.onnx",
+        help="Path to exported ONNX model",
+    )
+    parser.add_argument(
+        "--opset",
+        type=int,
+        default=18,
+        help="ONNX opset version",
+    )
+    return parser.parse_args()
+
+
+def build_model(image_size: int, head_hidden_dim: int, dropout: float):
+    return RPSClassifier(
+        image_size=image_size, head_hidden_dim=head_hidden_dim, dropout=dropout
+    )
+
+
+def load_metadata(checkpoint_path: Path):
+    metadata_path = checkpoint_path.parent / "metadata.json"
+    if metadata_path.exists():
+        return json.loads(metadata_path.read_text(encoding="utf-8"))
+    return {}
+
+
+def merge_external_data_if_needed(output_path: Path) -> None:
+    external_data_path = output_path.with_suffix(output_path.suffix + ".data")
+    if not external_data_path.exists():
+        return
+
+    model = onnx.load(str(output_path), load_external_data=True)
+    onnx.save_model(
+        model,
+        str(output_path),
+        save_as_external_data=False,
+    )
+    external_data_path.unlink()
+
+
+def main():
+    args = parse_args()
+    checkpoint_path = Path(args.checkpoint)
+    output_path = Path(args.output_path)
+
+    if not checkpoint_path.exists():
+        raise RuntimeError(f"checkpoint not found: {checkpoint_path}")
+
+    checkpoint = torch.load(checkpoint_path, map_location="cpu")
+    metadata = load_metadata(checkpoint_path)
+    image_size = checkpoint.get("image_size") or metadata.get("image_size", MODEL_IMAGE_SIZE)
+    if image_size != MODEL_IMAGE_SIZE:
+        raise RuntimeError(
+            f"this export script only supports fixed image size {MODEL_IMAGE_SIZE}, got {image_size}"
+        )
+    head_hidden_dim = checkpoint.get(
+        "head_hidden_dim", metadata.get("head_hidden_dim", 256)
+    )
+    dropout = checkpoint.get("dropout", metadata.get("dropout", 0.2))
+
+    model = build_model(
+        image_size=MODEL_IMAGE_SIZE,
+        head_hidden_dim=head_hidden_dim,
+        dropout=dropout,
+    )
+    model.load_state_dict(checkpoint["model_state_dict"])
+    model.eval()
+
+    export_model = RPSOnnxWrapper(model).eval()
+    dummy_input = torch.randn(
+        1, 3, MODEL_IMAGE_SIZE, MODEL_IMAGE_SIZE, dtype=torch.float32
+    )
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with torch.no_grad():
+        torch.onnx.export(
+            export_model,
+            dummy_input,
+            str(output_path),
+            input_names=["input"],
+            output_names=["confidence"],
+            opset_version=args.opset,
+            external_data=False,
+            do_constant_folding=True,
+            dynamic_axes=None,
+        )
+
+    merge_external_data_if_needed(output_path)
+
+    print(f"Checkpoint : {checkpoint_path}")
+    print(f"Image size : 1x3x{MODEL_IMAGE_SIZE}x{MODEL_IMAGE_SIZE}")
+    print(f"Head dim   : {head_hidden_dim}")
+    print(f"Dropout    : {dropout}")
+    print(f"Output     : {output_path}")
+    print("Dynamic axes disabled")
+
+
+if __name__ == "__main__":
+    main()

--- a/demo-rps/dataprocess_modeltrain/generate_negative_dataset.py
+++ b/demo-rps/dataprocess_modeltrain/generate_negative_dataset.py
@@ -1,0 +1,260 @@
+import argparse
+import math
+import random
+from pathlib import Path
+
+import cv2
+
+
+VIDEO_EXTENSIONS = {".mp4", ".avi", ".mov", ".mkv", ".mpg", ".mpeg"}
+DEFAULT_SOURCE_DIR = "/mnt/hdd16t0/dataset/rps_dataset/datasets"
+DEFAULT_OUTPUT_DIR = "/mnt/hdd16t0/dataset/rps_dataset/processed_dataset/N"
+DEFAULT_TARGET_CROP = (210, 270, 750, 810)  # x1, y1, x2, y2
+
+
+def iter_video_files(dataset_dir: Path) -> list[Path]:
+    videos = []
+    for path in sorted(dataset_dir.rglob("*")):
+        if path.is_file() and path.suffix.lower() in VIDEO_EXTENSIONS:
+            videos.append(path)
+    return videos
+
+
+def parse_crop(values: list[int]) -> tuple[int, int, int, int]:
+    if len(values) != 4:
+        raise ValueError("crop must contain exactly 4 integers: x1 y1 x2 y2")
+    x1, y1, x2, y2 = values
+    if x1 < 0 or y1 < 0 or x2 <= x1 or y2 <= y1:
+        raise ValueError("invalid crop range, expected x2 > x1 and y2 > y1")
+    return x1, y1, x2, y2
+
+
+def sample_frame_indices(
+    frame_count: int, samples_per_video: int, rng: random.Random
+) -> list[int]:
+    sample_count = min(frame_count, samples_per_video)
+    indices = []
+
+    for i in range(sample_count):
+        start = math.floor(i * frame_count / sample_count)
+        end = math.floor((i + 1) * frame_count / sample_count) - 1
+        end = max(start, end)
+        indices.append(rng.randint(start, end))
+
+    return sorted(set(indices))
+
+
+def rectangles_overlap(
+    rect_a: tuple[int, int, int, int], rect_b: tuple[int, int, int, int]
+) -> bool:
+    ax1, ay1, ax2, ay2 = rect_a
+    bx1, by1, bx2, by2 = rect_b
+    return not (ax2 <= bx1 or bx2 <= ax1 or ay2 <= by1 or by2 <= ay1)
+
+
+def sample_negative_crop(
+    frame_width: int,
+    frame_height: int,
+    crop_width: int,
+    crop_height: int,
+    target_crop: tuple[int, int, int, int],
+    rng: random.Random,
+    max_attempts: int = 200,
+) -> tuple[int, int, int, int]:
+    max_x = frame_width - crop_width
+    max_y = frame_height - crop_height
+    if max_x < 0 or max_y < 0:
+        raise RuntimeError(
+            f"crop size {(crop_width, crop_height)} exceeds frame size {(frame_width, frame_height)}"
+        )
+
+    for _ in range(max_attempts):
+        x1 = rng.randint(0, max_x)
+        y1 = rng.randint(0, max_y)
+        candidate = (x1, y1, x1 + crop_width, y1 + crop_height)
+        if not rectangles_overlap(candidate, target_crop):
+            return candidate
+
+    step = 10
+    candidates = []
+    for x1 in range(0, max_x + 1, step):
+        for y1 in range(0, max_y + 1, step):
+            candidate = (x1, y1, x1 + crop_width, y1 + crop_height)
+            if not rectangles_overlap(candidate, target_crop):
+                candidates.append(candidate)
+
+    if not candidates:
+        raise RuntimeError(
+            "no valid negative crop found that does not overlap the target crop"
+        )
+
+    return rng.choice(candidates)
+
+
+def read_frame_with_fallback(
+    capture: cv2.VideoCapture,
+    frame_index: int,
+    frame_count: int,
+    search_radius: int = 5,
+):
+    candidate_indices = [frame_index]
+    for offset in range(1, search_radius + 1):
+        lower = frame_index - offset
+        upper = frame_index + offset
+        if lower >= 0:
+            candidate_indices.append(lower)
+        if upper < frame_count:
+            candidate_indices.append(upper)
+
+    for candidate_index in candidate_indices:
+        capture.set(cv2.CAP_PROP_POS_FRAMES, candidate_index)
+        ok, frame = capture.read()
+        if ok and frame is not None:
+            return candidate_index, frame
+
+    raise RuntimeError(
+        f"failed to read frame {frame_index} and nearby frames within radius {search_radius}"
+    )
+
+
+def process_video(
+    video_path: Path,
+    output_dir: Path,
+    target_crop: tuple[int, int, int, int],
+    samples_per_video: int,
+    image_ext: str,
+    rng: random.Random,
+) -> int:
+    capture = cv2.VideoCapture(str(video_path))
+    if not capture.isOpened():
+        raise RuntimeError(f"failed to open video: {video_path}")
+
+    frame_count = int(capture.get(cv2.CAP_PROP_FRAME_COUNT))
+    frame_width = int(capture.get(cv2.CAP_PROP_FRAME_WIDTH))
+    frame_height = int(capture.get(cv2.CAP_PROP_FRAME_HEIGHT))
+    if frame_count <= 0:
+        capture.release()
+        raise RuntimeError(f"failed to read frame count: {video_path}")
+
+    tx1, ty1, tx2, ty2 = target_crop
+    crop_width = tx2 - tx1
+    crop_height = ty2 - ty1
+
+    frame_indices = sample_frame_indices(frame_count, samples_per_video, rng)
+    saved_count = 0
+
+    for frame_index in frame_indices:
+        actual_frame_index, frame = read_frame_with_fallback(
+            capture=capture,
+            frame_index=frame_index,
+            frame_count=frame_count,
+        )
+
+        crop_rect = sample_negative_crop(
+            frame_width=frame_width,
+            frame_height=frame_height,
+            crop_width=crop_width,
+            crop_height=crop_height,
+            target_crop=target_crop,
+            rng=rng,
+        )
+        x1, y1, x2, y2 = crop_rect
+        cropped = frame[y1:y2, x1:x2]
+
+        output_name = (
+            f"{video_path.stem}_frame_{actual_frame_index:06d}_neg_x{x1}_y{y1}{image_ext}"
+        )
+        output_path = output_dir / output_name
+        if not cv2.imwrite(str(output_path), cropped):
+            raise RuntimeError(f"failed to save frame: {output_path}")
+
+        saved_count += 1
+
+    capture.release()
+    return saved_count
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Sample negative crops from videos and save them as class N"
+    )
+    parser.add_argument(
+        "--dataset_dir",
+        type=str,
+        default=DEFAULT_SOURCE_DIR,
+        help="Input video dataset root directory",
+    )
+    parser.add_argument(
+        "--output_dir",
+        type=str,
+        default=DEFAULT_OUTPUT_DIR,
+        help="Output directory for negative class N images",
+    )
+    parser.add_argument(
+        "--target_crop",
+        nargs=4,
+        type=int,
+        default=DEFAULT_TARGET_CROP,
+        metavar=("X1", "Y1", "X2", "Y2"),
+        help="Target crop region to avoid: x1 y1 x2 y2",
+    )
+    parser.add_argument(
+        "--samples_per_video",
+        type=int,
+        default=100,
+        help="Number of frames to sample per video",
+    )
+    parser.add_argument(
+        "--image_ext",
+        type=str,
+        default=".png",
+        choices=[".png", ".jpg", ".jpeg", ".bmp"],
+        help="Image extension for saved frames",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        help="Random seed for reproducibility",
+    )
+    args = parser.parse_args()
+
+    dataset_dir = Path(args.dataset_dir)
+    output_dir = Path(args.output_dir)
+    target_crop = parse_crop(list(args.target_crop))
+
+    if not dataset_dir.exists():
+        raise RuntimeError(f"dataset directory not found: {dataset_dir}")
+
+    videos = iter_video_files(dataset_dir)
+    if not videos:
+        raise RuntimeError(f"no video files found under: {dataset_dir}")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    rng = random.Random(args.seed)
+
+    print(f"Found {len(videos)} videos under {dataset_dir}")
+    print(f"Target crop to avoid : {target_crop}")
+    print(f"Samples per video    : {args.samples_per_video}")
+    print(f"Output dir           : {output_dir}")
+
+    total_saved = 0
+    for index, video_path in enumerate(videos, start=1):
+        saved_count = process_video(
+            video_path=video_path,
+            output_dir=output_dir,
+            target_crop=target_crop,
+            samples_per_video=args.samples_per_video,
+            image_ext=args.image_ext,
+            rng=rng,
+        )
+        total_saved += saved_count
+        print(
+            f"[{index}/{len(videos)}] {video_path.name} -> N, saved {saved_count} frames"
+        )
+
+    print(f"Finished. Total saved frames: {total_saved}")
+
+
+if __name__ == "__main__":
+    main()

--- a/demo-rps/dataprocess_modeltrain/infer_rps_classifier.py
+++ b/demo-rps/dataprocess_modeltrain/infer_rps_classifier.py
@@ -1,0 +1,142 @@
+import argparse
+import json
+from pathlib import Path
+
+import timm
+import torch
+from PIL import Image
+from torch import nn
+from torchvision import transforms
+
+MODEL_IMAGE_SIZE = 320
+
+
+class RPSClassifier(nn.Module):
+    def __init__(self, image_size: int, head_hidden_dim: int, dropout: float):
+        super().__init__()
+        self.backbone = timm.create_model(
+            "mobilenetv1_100",
+            pretrained=False,
+            num_classes=0,
+            global_pool="",
+        )
+        feature_channels, feature_height, feature_width = self._infer_feature_shape(
+            image_size
+        )
+        self.head = nn.Sequential(
+            nn.Conv2d(feature_channels, head_hidden_dim, kernel_size=1, bias=False),
+            nn.BatchNorm2d(head_hidden_dim),
+            nn.ReLU(inplace=True),
+            nn.Dropout2d(p=dropout),
+            nn.Conv2d(
+                head_hidden_dim,
+                3,
+                kernel_size=(feature_height, feature_width),
+                bias=True,
+            ),
+            nn.Flatten(1),
+        )
+
+    def _infer_feature_shape(self, image_size: int):
+        was_training = self.backbone.training
+        self.backbone.eval()
+        with torch.no_grad():
+            dummy = torch.zeros(1, 3, image_size, image_size)
+            features = self.backbone(dummy)
+        if was_training:
+            self.backbone.train()
+        return features.shape[1], features.shape[2], features.shape[3]
+
+    def forward(self, x):
+        features = self.backbone(x)
+        logits = self.head(features)
+        return logits
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Inference for 3-output Rock/Paper/Scissors confidence model"
+    )
+    parser.add_argument(
+        "--image_path",
+        type=str,
+        required=True,
+        help="Path to one image for inference",
+    )
+    parser.add_argument(
+        "--checkpoint",
+        type=str,
+        required=True,
+        help="Path to trained checkpoint .pt",
+    )
+    return parser.parse_args()
+
+
+def build_model(image_size: int, head_hidden_dim: int, dropout: float):
+    return RPSClassifier(
+        image_size=image_size, head_hidden_dim=head_hidden_dim, dropout=dropout
+    )
+
+
+def build_transform(image_size: int):
+    return transforms.Compose(
+        [
+            transforms.Resize((image_size, image_size)),
+            transforms.ToTensor(),
+            transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
+        ]
+    )
+
+
+def load_metadata(checkpoint_path: Path):
+    metadata_path = checkpoint_path.parent / "metadata.json"
+    if metadata_path.exists():
+        return json.loads(metadata_path.read_text(encoding="utf-8"))
+    return {}
+
+
+def main():
+    args = parse_args()
+    checkpoint_path = Path(args.checkpoint)
+    image_path = Path(args.image_path)
+
+    if not checkpoint_path.exists():
+        raise RuntimeError(f"checkpoint not found: {checkpoint_path}")
+    if not image_path.exists():
+        raise RuntimeError(f"image not found: {image_path}")
+
+    checkpoint = torch.load(checkpoint_path, map_location="cpu")
+    metadata = load_metadata(checkpoint_path)
+    output_classes = checkpoint.get("output_classes", ["P", "R", "S"])
+    image_size = checkpoint.get("image_size") or metadata.get("image_size", MODEL_IMAGE_SIZE)
+    if image_size != MODEL_IMAGE_SIZE:
+        raise RuntimeError(
+            f"this inference script only supports fixed image size {MODEL_IMAGE_SIZE}, got {image_size}"
+        )
+    head_hidden_dim = checkpoint.get(
+        "head_hidden_dim", metadata.get("head_hidden_dim", 256)
+    )
+    dropout = checkpoint.get("dropout", metadata.get("dropout", 0.2))
+
+    model = build_model(
+        image_size=image_size,
+        head_hidden_dim=head_hidden_dim,
+        dropout=dropout,
+    )
+    model.load_state_dict(checkpoint["model_state_dict"])
+    model.eval()
+
+    transform = build_transform(MODEL_IMAGE_SIZE)
+    image = Image.open(image_path).convert("RGB")
+    tensor = transform(image).unsqueeze(0)
+
+    with torch.no_grad():
+        logits = model(tensor)
+        probs = torch.sigmoid(logits)[0].tolist()
+
+    result = {class_name: float(score) for class_name, score in zip(output_classes, probs)}
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/demo-rps/dataprocess_modeltrain/prepare_video_dataset.py
+++ b/demo-rps/dataprocess_modeltrain/prepare_video_dataset.py
@@ -49,6 +49,14 @@ def center_crop(frame):
     return frame[top:bottom, left:right]
 
 
+def to_grayscale(frame):
+    if len(frame.shape) == 2:
+        return frame
+    if frame.shape[2] == 1:
+        return frame[:, :, 0]
+    return cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+
+
 def split_videos(videos: list[Path], train_ratio: float, val_ratio: float) -> dict[str, list[Path]]:
     total = len(videos)
     train_count = int(total * train_ratio)
@@ -100,7 +108,7 @@ def process_video(
             )
 
         if frame_index % frame_step == 0:
-            cropped = center_cropped[y1:y2, x1:x2]
+            cropped = to_grayscale(center_cropped[y1:y2, x1:x2])
             output_name = f"{video_path.stem}_frame_{frame_index:06d}{image_ext}"
             output_path = class_output_dir / output_name
 

--- a/demo-rps/dataprocess_modeltrain/requirements.txt
+++ b/demo-rps/dataprocess_modeltrain/requirements.txt
@@ -1,0 +1,7 @@
+torch
+torchvision
+timm
+opencv-python-headless
+numpy
+Pillow
+onnx

--- a/demo-rps/dataprocess_modeltrain/save_bin.py
+++ b/demo-rps/dataprocess_modeltrain/save_bin.py
@@ -1,0 +1,171 @@
+import argparse
+import random
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+
+IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".bmp", ".tif", ".tiff"}
+MODEL_IMAGE_SIZE = 320
+NORM_MEAN = np.array([0.485, 0.456, 0.406], dtype=np.float32).reshape(3, 1, 1)
+NORM_STD = np.array([0.229, 0.224, 0.225], dtype=np.float32).reshape(3, 1, 1)
+
+
+def preprocess_image(img_path: Path, image_size: int) -> np.ndarray:
+    img_bgr = cv2.imread(str(img_path), cv2.IMREAD_COLOR)
+    if img_bgr is None:
+        raise RuntimeError(f"Failed to read image: {img_path}")
+
+    img_rgb = cv2.cvtColor(img_bgr, cv2.COLOR_BGR2RGB)
+    img_rgb = cv2.resize(
+        img_rgb,
+        (image_size, image_size),
+        interpolation=cv2.INTER_LINEAR,
+    )
+    img_rgb = img_rgb.astype(np.float32) / 255.0
+    img_chw = np.transpose(img_rgb, (2, 0, 1))
+    img_chw = (img_chw - NORM_MEAN) / NORM_STD
+    img_nchw = np.expand_dims(img_chw, axis=0)
+    return img_nchw.astype(np.float32)
+
+
+def collect_images_from_dataset(dataset_dir: Path) -> list[Path]:
+    image_paths = []
+    if not dataset_dir.exists():
+        raise RuntimeError(f"Dataset directory not found: {dataset_dir}")
+
+    for path in sorted(dataset_dir.rglob("*")):
+        if path.is_file() and path.suffix.lower() in IMAGE_EXTENSIONS:
+            image_paths.append(path)
+    return image_paths
+
+
+def save_tensor_set(
+    image_paths: list[Path],
+    output_dir: Path,
+    image_size: int,
+    set_name: str,
+    output_format: str,
+) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    manifest_lines = []
+    for idx, img_path in enumerate(image_paths):
+        tensor = preprocess_image(img_path, image_size)
+        if output_format == "npy":
+            out_path = output_dir / f"{idx:04d}_{img_path.stem}.npy"
+            np.save(out_path, tensor)
+        else:
+            out_path = output_dir / f"{idx:04d}_{img_path.stem}.bin"
+            tensor.tofile(out_path)
+        manifest_lines.append(
+            f"{out_path.name}\t{img_path}\tshape={tuple(tensor.shape)}\tdtype=float32"
+        )
+
+    manifest_path = output_dir / f"{set_name}_manifest.txt"
+    manifest_path.write_text("\n".join(manifest_lines), encoding="utf-8")
+
+    print(f"=== {set_name.capitalize()} set generated ===")
+    print(f"  Image count : {len(image_paths)}")
+    print(f"  Output dir  : {output_dir}")
+    print(f"  Tensor shape: (1, 3, {image_size}, {image_size})")
+    print(f"  Tensor dtype: float32")
+    print(f"  Layout      : NCHW")
+    print("  Normalize   : mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]")
+    print(f"  Format      : {output_format}")
+    print(f"  Manifest    : {manifest_path}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate calibration and evaluation tensors with current model preprocessing"
+    )
+    parser.add_argument(
+        "--dataset_dir",
+        type=str,
+        default="/mnt/hdd16t0/dataset/rps_dataset/processed_dataset",
+        help="Dataset root dir containing class subdirectories",
+    )
+    parser.add_argument(
+        "--output_dir",
+        type=str,
+        default="/home/hehongying/Rock-paper-scissors/calibrate_datasets_bin",
+        help="Root dir to save calibrate_datasets/ and evaluate_datasets/",
+    )
+    parser.add_argument(
+        "--image_size",
+        type=int,
+        default=MODEL_IMAGE_SIZE,
+        help="Fixed model image size. Current pipeline uses 320.",
+    )
+    parser.add_argument(
+        "--output_format",
+        type=str,
+        default="npy",
+        choices=["npy", "bin"],
+        help="Output tensor file format",
+    )
+    parser.add_argument(
+        "--cal_num",
+        type=int,
+        default=50,
+        help="Number of random images for calibration set",
+    )
+    parser.add_argument(
+        "--eval_num",
+        type=int,
+        default=20,
+        help="Number of random images for evaluation set",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        help="Random seed for reproducibility",
+    )
+    args = parser.parse_args()
+
+    if args.image_size != MODEL_IMAGE_SIZE:
+        raise RuntimeError(
+            f"Current model preprocessing is fixed to {MODEL_IMAGE_SIZE}, got {args.image_size}"
+        )
+
+    dataset_dir = Path(args.dataset_dir)
+    output_dir = Path(args.output_dir)
+
+    all_images = collect_images_from_dataset(dataset_dir)
+    if not all_images:
+        raise RuntimeError(f"No images found under: {dataset_dir}")
+
+    total = len(all_images)
+    if total < args.cal_num + args.eval_num:
+        raise RuntimeError(
+            f"Not enough images ({total}) for cal({args.cal_num}) + eval({args.eval_num})"
+        )
+
+    print(f"Total images found: {total}")
+
+    rng = random.Random(args.seed)
+    rng.shuffle(all_images)
+    cal_paths = all_images[: args.cal_num]
+    eval_paths = all_images[args.cal_num : args.cal_num + args.eval_num]
+
+    save_tensor_set(
+        image_paths=cal_paths,
+        output_dir=output_dir / "calibrate_datasets",
+        image_size=MODEL_IMAGE_SIZE,
+        set_name="calibration",
+        output_format=args.output_format,
+    )
+    save_tensor_set(
+        image_paths=eval_paths,
+        output_dir=output_dir / "evaluate_datasets",
+        image_size=MODEL_IMAGE_SIZE,
+        set_name="evaluation",
+        output_format=args.output_format,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/demo-rps/dataprocess_modeltrain/train_a1_5class_classifier.py
+++ b/demo-rps/dataprocess_modeltrain/train_a1_5class_classifier.py
@@ -17,8 +17,9 @@ CLASS_TO_INDEX = {name: idx for idx, name in enumerate(CLASS_NAMES)}
 IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".bmp"}
 MODEL_IMAGE_SIZE = 320
 NUM_CLASSES = len(CLASS_NAMES)
-MEAN = [0.485, 0.456, 0.406]
-STD = [0.229, 0.224, 0.225]
+INPUT_CHANNELS = 1
+MEAN = [0.5]
+STD = [0.5]
 
 
 class A1Classifier(nn.Module):
@@ -29,6 +30,7 @@ class A1Classifier(nn.Module):
             pretrained=pretrained,
             num_classes=0,
             global_pool="",
+            in_chans=INPUT_CHANNELS,
         )
         feature_channels = self._infer_feature_channels(image_size)
         self.head = nn.Sequential(
@@ -45,7 +47,7 @@ class A1Classifier(nn.Module):
         was_training = self.backbone.training
         self.backbone.eval()
         with torch.no_grad():
-            dummy = torch.zeros(1, 3, image_size, image_size)
+            dummy = torch.zeros(1, INPUT_CHANNELS, image_size, image_size)
             features = self.backbone(dummy)
         if was_training:
             self.backbone.train()
@@ -65,7 +67,7 @@ class ClassImageDataset(Dataset):
 
     def __getitem__(self, index):
         image_path, label = self.samples[index]
-        image = Image.open(image_path).convert("RGB")
+        image = Image.open(image_path).convert("L")
         return self.transform(image), label, str(image_path)
 
 
@@ -79,7 +81,7 @@ def parse_args():
     parser.add_argument("--weight_decay", type=float, default=1e-4)
     parser.add_argument("--num_workers", type=int, default=4)
     parser.add_argument("--seed", type=int, default=42)
-    parser.add_argument("--pretrained", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--pretrained", action=argparse.BooleanOptionalAction, default=False)
     parser.add_argument("--head_hidden_dim", type=int, default=256)
     parser.add_argument("--dropout", type=float, default=0.2)
     parser.add_argument("--export_onnx", action="store_true")
@@ -132,7 +134,6 @@ def build_transforms(image_size: int):
             transforms.Resize((image_size + 16, image_size + 16)),
             transforms.RandomResizedCrop(image_size, scale=(0.9, 1.0), ratio=(0.95, 1.05)),
             transforms.RandomHorizontalFlip(p=0.5),
-            transforms.ColorJitter(brightness=0.12, contrast=0.12, saturation=0.08, hue=0.03),
             transforms.ToTensor(),
             transforms.Normalize(mean=MEAN, std=STD),
         ]
@@ -148,7 +149,12 @@ def build_transforms(image_size: int):
 
 
 def build_model(pretrained: bool, image_size: int, head_hidden_dim: int, dropout: float):
-    return A1Classifier(pretrained, image_size, head_hidden_dim, dropout)
+    return A1Classifier(
+        pretrained=pretrained,
+        image_size=image_size,
+        head_hidden_dim=head_hidden_dim,
+        dropout=dropout,
+    )
 
 
 def confusion_matrix(preds: torch.Tensor, targets: torch.Tensor, num_classes: int):
@@ -211,6 +217,7 @@ def save_metadata(output_dir: Path, args, train_count: int, val_count: int, test
         "model_name": "mobilenetv1_100",
         "class_names": CLASS_NAMES,
         "num_classes": NUM_CLASSES,
+        "input_channels": INPUT_CHANNELS,
         "image_size": MODEL_IMAGE_SIZE,
         "dataset_dir": args.dataset_dir,
         "head_hidden_dim": args.head_hidden_dim,
@@ -231,7 +238,7 @@ def export_onnx_model(checkpoint_path: Path, onnx_path: Path, pretrained: bool, 
     model = build_model(pretrained, image_size, head_hidden_dim, dropout)
     model.load_state_dict(checkpoint["model_state_dict"])
     model.eval()
-    dummy_input = torch.randn(1, 3, image_size, image_size)
+    dummy_input = torch.randn(1, INPUT_CHANNELS, image_size, image_size)
     onnx_path.parent.mkdir(parents=True, exist_ok=True)
     with torch.no_grad():
         torch.onnx.export(
@@ -291,6 +298,7 @@ def main():
     print(f"Device      : {device}")
     print(f"Classes     : {CLASS_NAMES}")
     print(f"Image size  : {MODEL_IMAGE_SIZE}")
+    print(f"Input chans : {INPUT_CHANNELS}")
     print(f"Output dir  : {output_dir}")
 
     for epoch in range(1, args.epochs + 1):
@@ -303,6 +311,7 @@ def main():
             "epoch": epoch,
             "image_size": MODEL_IMAGE_SIZE,
             "class_names": CLASS_NAMES,
+            "input_channels": INPUT_CHANNELS,
             "head_hidden_dim": args.head_hidden_dim,
             "dropout": args.dropout,
         }

--- a/demo-rps/dataprocess_modeltrain/train_rps_classifier.py
+++ b/demo-rps/dataprocess_modeltrain/train_rps_classifier.py
@@ -1,0 +1,474 @@
+import argparse
+import copy
+import json
+import random
+from collections import Counter
+from pathlib import Path
+
+import timm
+import torch
+from PIL import Image
+from torch import nn
+from torch.utils.data import DataLoader, Dataset
+from torchvision import transforms
+
+
+CLASS_NAMES = ["person", "stop", "forward", "obstacle", "NoTarget"]
+CLASS_TO_INDEX = {name: idx for idx, name in enumerate(CLASS_NAMES)}
+IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".bmp"}
+MODEL_IMAGE_SIZE = 320
+NUM_CLASSES = len(CLASS_NAMES)
+MEAN = [0.485, 0.456, 0.406]
+STD = [0.229, 0.224, 0.225]
+
+
+class RPSClassifier(nn.Module):
+    def __init__(
+        self,
+        pretrained: bool,
+        image_size: int,
+        head_hidden_dim: int,
+        dropout: float,
+    ):
+        super().__init__()
+        self.backbone = timm.create_model(
+            "mobilenetv1_100",
+            pretrained=pretrained,
+            num_classes=0,
+            global_pool="",
+        )
+        feature_channels = self._infer_feature_channels(image_size)
+        self.head = nn.Sequential(
+            nn.Conv2d(feature_channels, head_hidden_dim, kernel_size=1, bias=False),
+            nn.BatchNorm2d(head_hidden_dim),
+            nn.ReLU(inplace=True),
+            nn.Dropout(p=dropout),
+            nn.AdaptiveAvgPool2d(1),
+            nn.Flatten(1),
+            nn.Linear(head_hidden_dim, NUM_CLASSES),
+        )
+
+    def _infer_feature_channels(self, image_size: int):
+        was_training = self.backbone.training
+        self.backbone.eval()
+        with torch.no_grad():
+            dummy = torch.zeros(1, 3, image_size, image_size)
+            features = self.backbone(dummy)
+        if was_training:
+            self.backbone.train()
+        return features.shape[1]
+
+    def forward(self, x):
+        features = self.backbone(x)
+        logits = self.head(features)
+        return logits
+
+
+class ClassImageDataset(Dataset):
+    def __init__(self, samples, transform):
+        self.samples = samples
+        self.transform = transform
+
+    def __len__(self):
+        return len(self.samples)
+
+    def __getitem__(self, index):
+        image_path, label = self.samples[index]
+        image = Image.open(image_path).convert("RGB")
+        image = self.transform(image)
+        return image, label, str(image_path)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Train a 5-class single-label classifier")
+    parser.add_argument(
+        "--dataset_dir",
+        type=str,
+        default="/mnt/hdd16t0/dataset/rps_dataset/processed_dataset",
+        help="Dataset root dir with train/val/test/<class> subdirectories",
+    )
+    parser.add_argument(
+        "--output_dir",
+        type=str,
+        default="outputs/rps_mobilenetv1_5class",
+        help="Directory to save checkpoints and metadata",
+    )
+    parser.add_argument("--batch_size", type=int, default=64, help="Batch size")
+    parser.add_argument("--epochs", type=int, default=30, help="Number of training epochs")
+    parser.add_argument("--lr", type=float, default=1e-3, help="Initial learning rate")
+    parser.add_argument(
+        "--weight_decay", type=float, default=1e-4, help="AdamW weight decay"
+    )
+    parser.add_argument("--num_workers", type=int, default=4, help="Dataloader worker count")
+    parser.add_argument("--seed", type=int, default=42, help="Random seed")
+    parser.add_argument(
+        "--pretrained",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Load pretrained MobileNetV1 weights from timm",
+    )
+    parser.add_argument(
+        "--head_hidden_dim",
+        type=int,
+        default=256,
+        help="Hidden dimension of the custom classification head",
+    )
+    parser.add_argument(
+        "--dropout",
+        type=float,
+        default=0.2,
+        help="Dropout used in the custom classification head",
+    )
+    parser.add_argument(
+        "--export_onnx",
+        action="store_true",
+        help="Export best checkpoint to ONNX after training",
+    )
+    parser.add_argument(
+        "--onnx_path",
+        type=str,
+        default=None,
+        help="Output path for ONNX export; defaults to <output_dir>/best.onnx",
+    )
+    return parser.parse_args()
+
+
+def seed_everything(seed: int) -> None:
+    random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+
+
+def list_split_samples(split_dir: Path):
+    samples_by_class = {}
+    for class_name in CLASS_NAMES:
+        class_dir = split_dir / class_name
+        items = []
+        if class_dir.exists():
+            for path in sorted(class_dir.rglob("*")):
+                if path.is_file() and path.suffix.lower() in IMAGE_EXTENSIONS:
+                    items.append((path, CLASS_TO_INDEX[class_name]))
+        samples_by_class[class_name] = items
+    return samples_by_class
+
+
+def flatten_samples(samples_by_class):
+    samples = []
+    for class_name in CLASS_NAMES:
+        samples.extend(samples_by_class.get(class_name, []))
+    return samples
+
+
+def summarize_split(split_name: str, samples_by_class):
+    counts = {class_name: len(samples_by_class.get(class_name, [])) for class_name in CLASS_NAMES}
+    total = sum(counts.values())
+    counts_text = " ".join(f"{name}={counts[name]}" for name in CLASS_NAMES)
+    print(f"{split_name}: total={total} {counts_text}")
+
+
+def verify_required_classes(split_name: str, samples_by_class):
+    missing = [class_name for class_name in CLASS_NAMES if not samples_by_class.get(class_name)]
+    if missing:
+        raise RuntimeError(f"{split_name} split missing class data: {missing}")
+
+
+def build_transforms(image_size: int):
+    train_transform = transforms.Compose(
+        [
+            transforms.Resize((image_size + 16, image_size + 16)),
+            transforms.RandomResizedCrop(image_size, scale=(0.9, 1.0), ratio=(0.95, 1.05)),
+            transforms.RandomHorizontalFlip(p=0.5),
+            transforms.ColorJitter(brightness=0.12, contrast=0.12, saturation=0.08, hue=0.03),
+            transforms.ToTensor(),
+            transforms.Normalize(mean=MEAN, std=STD),
+        ]
+    )
+    eval_transform = transforms.Compose(
+        [
+            transforms.Resize((image_size, image_size)),
+            transforms.ToTensor(),
+            transforms.Normalize(mean=MEAN, std=STD),
+        ]
+    )
+    return train_transform, eval_transform
+
+
+def build_model(pretrained: bool, image_size: int, head_hidden_dim: int, dropout: float):
+    return RPSClassifier(
+        pretrained=pretrained,
+        image_size=image_size,
+        head_hidden_dim=head_hidden_dim,
+        dropout=dropout,
+    )
+
+
+def confusion_matrix(preds: torch.Tensor, targets: torch.Tensor, num_classes: int):
+    matrix = torch.zeros((num_classes, num_classes), dtype=torch.int64)
+    for target, pred in zip(targets.tolist(), preds.tolist()):
+        matrix[target, pred] += 1
+    return matrix
+
+
+def accuracy_from_logits(logits: torch.Tensor, targets: torch.Tensor):
+    preds = logits.argmax(dim=1)
+    return (preds == targets).float().mean().item()
+
+
+def run_epoch(model, loader, criterion, optimizer, device):
+    is_train = optimizer is not None
+    model.train(is_train)
+
+    total_loss = 0.0
+    total_items = 0
+    all_logits = []
+    all_targets = []
+
+    for images, targets, _ in loader:
+        images = images.to(device, non_blocking=True)
+        targets = targets.to(device, non_blocking=True)
+
+        with torch.set_grad_enabled(is_train):
+            logits = model(images)
+            loss = criterion(logits, targets)
+            if is_train:
+                optimizer.zero_grad(set_to_none=True)
+                loss.backward()
+                optimizer.step()
+
+        batch_size = images.size(0)
+        total_loss += loss.item() * batch_size
+        total_items += batch_size
+        all_logits.append(logits.detach().cpu())
+        all_targets.append(targets.detach().cpu())
+
+    logits = torch.cat(all_logits, dim=0) if all_logits else torch.empty(0, NUM_CLASSES)
+    targets = torch.cat(all_targets, dim=0) if all_targets else torch.empty(0, dtype=torch.long)
+    metrics = {
+        "loss": total_loss / max(total_items, 1),
+        "top1": accuracy_from_logits(logits, targets) if total_items else 0.0,
+        "preds": logits.argmax(dim=1) if total_items else torch.empty(0, dtype=torch.long),
+        "targets": targets,
+    }
+    return metrics
+
+
+def format_confusion_matrix(matrix: torch.Tensor):
+    header = "          " + " ".join(f"{name:>9}" for name in CLASS_NAMES)
+    rows = [header]
+    for idx, name in enumerate(CLASS_NAMES):
+        values = " ".join(f"{int(v):9d}" for v in matrix[idx].tolist())
+        rows.append(f"{name:>9} {values}")
+    return "\n".join(rows)
+
+
+def save_metadata(output_dir: Path, args, train_count: int, val_count: int, test_count: int):
+    metadata = {
+        "model_name": "mobilenetv1_100",
+        "class_names": CLASS_NAMES,
+        "num_classes": NUM_CLASSES,
+        "image_size": MODEL_IMAGE_SIZE,
+        "dataset_dir": args.dataset_dir,
+        "head_hidden_dim": args.head_hidden_dim,
+        "dropout": args.dropout,
+        "train_count": train_count,
+        "val_count": val_count,
+        "test_count": test_count,
+        "lr": args.lr,
+        "weight_decay": args.weight_decay,
+        "batch_size": args.batch_size,
+        "seed": args.seed,
+    }
+    metadata_path = output_dir / "metadata.json"
+    metadata_path.write_text(json.dumps(metadata, indent=2, ensure_ascii=False), encoding="utf-8")
+
+
+def load_checkpoint_model(checkpoint_path: Path, pretrained: bool, image_size: int, head_hidden_dim: int, dropout: float):
+    checkpoint = torch.load(checkpoint_path, map_location="cpu")
+    model = build_model(
+        pretrained=pretrained,
+        image_size=image_size,
+        head_hidden_dim=head_hidden_dim,
+        dropout=dropout,
+    )
+    model.load_state_dict(checkpoint["model_state_dict"])
+    model.eval()
+    return model, checkpoint
+
+
+def export_onnx_model(checkpoint_path: Path, onnx_path: Path, pretrained: bool, image_size: int, head_hidden_dim: int, dropout: float):
+    model, checkpoint = load_checkpoint_model(checkpoint_path, pretrained, image_size, head_hidden_dim, dropout)
+    dummy_input = torch.randn(1, 3, image_size, image_size)
+    onnx_path.parent.mkdir(parents=True, exist_ok=True)
+    with torch.no_grad():
+        torch.onnx.export(
+            model,
+            dummy_input,
+            str(onnx_path),
+            input_names=["input"],
+            output_names=["logits"],
+            opset_version=12,
+            do_constant_folding=True,
+            dynamic_axes={"input": {0: "batch"}, "logits": {0: "batch"}},
+        )
+    return checkpoint
+
+
+def main():
+    args = parse_args()
+    seed_everything(args.seed)
+
+    dataset_dir = Path(args.dataset_dir)
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    if not dataset_dir.exists():
+        raise RuntimeError(f"dataset directory not found: {dataset_dir}")
+
+    split_dirs = {split_name: dataset_dir / split_name for split_name in ["train", "val", "test"]}
+    train_samples_by_class = list_split_samples(split_dirs["train"])
+    val_samples_by_class = list_split_samples(split_dirs["val"])
+    test_samples_by_class = list_split_samples(split_dirs["test"])
+
+    verify_required_classes("train", train_samples_by_class)
+    verify_required_classes("val", val_samples_by_class)
+    if not any(test_samples_by_class.get(class_name) for class_name in CLASS_NAMES):
+        print("Warning: test split is empty or missing; final test evaluation will be skipped.")
+
+    summarize_split("train", train_samples_by_class)
+    summarize_split("val", val_samples_by_class)
+    summarize_split("test", test_samples_by_class)
+
+    train_samples = flatten_samples(train_samples_by_class)
+    val_samples = flatten_samples(val_samples_by_class)
+    test_samples = flatten_samples(test_samples_by_class)
+
+    train_transform, eval_transform = build_transforms(MODEL_IMAGE_SIZE)
+    train_dataset = ClassImageDataset(train_samples, train_transform)
+    val_dataset = ClassImageDataset(val_samples, eval_transform)
+    test_dataset = ClassImageDataset(test_samples, eval_transform) if test_samples else None
+
+    train_loader = DataLoader(
+        train_dataset,
+        batch_size=args.batch_size,
+        shuffle=True,
+        num_workers=args.num_workers,
+        pin_memory=True,
+    )
+    val_loader = DataLoader(
+        val_dataset,
+        batch_size=args.batch_size,
+        shuffle=False,
+        num_workers=args.num_workers,
+        pin_memory=True,
+    )
+    test_loader = (
+        DataLoader(
+            test_dataset,
+            batch_size=args.batch_size,
+            shuffle=False,
+            num_workers=args.num_workers,
+            pin_memory=True,
+        )
+        if test_dataset is not None
+        else None
+    )
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model = build_model(
+        pretrained=args.pretrained,
+        image_size=MODEL_IMAGE_SIZE,
+        head_hidden_dim=args.head_hidden_dim,
+        dropout=args.dropout,
+    ).to(device)
+    criterion = nn.CrossEntropyLoss()
+    optimizer = torch.optim.AdamW(model.parameters(), lr=args.lr, weight_decay=args.weight_decay)
+    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=max(args.epochs, 1))
+
+    best_metric = -1.0
+    best_checkpoint_path = output_dir / "best.pt"
+    last_checkpoint_path = output_dir / "last.pt"
+    best_state_dict = None
+
+    save_metadata(output_dir, args, len(train_dataset), len(val_dataset), len(test_dataset) if test_dataset is not None else 0)
+
+    print(f"Device      : {device}")
+    print(f"Image size  : {MODEL_IMAGE_SIZE}")
+    print(f"Train count : {len(train_dataset)}")
+    print(f"Val count   : {len(val_dataset)}")
+    print(f"Test count  : {len(test_dataset) if test_dataset is not None else 0}")
+    print(f"Output dir  : {output_dir}")
+
+    for epoch in range(1, args.epochs + 1):
+        train_metrics = run_epoch(
+            model=model,
+            loader=train_loader,
+            criterion=criterion,
+            optimizer=optimizer,
+            device=device,
+        )
+        val_metrics = run_epoch(
+            model=model,
+            loader=val_loader,
+            criterion=criterion,
+            optimizer=None,
+            device=device,
+        )
+        scheduler.step()
+
+        checkpoint = {
+            "model_state_dict": copy.deepcopy(model.state_dict()),
+            "epoch": epoch,
+            "image_size": MODEL_IMAGE_SIZE,
+            "class_names": CLASS_NAMES,
+            "head_hidden_dim": args.head_hidden_dim,
+            "dropout": args.dropout,
+        }
+        torch.save(checkpoint, last_checkpoint_path)
+
+        if val_metrics["top1"] > best_metric:
+            best_metric = val_metrics["top1"]
+            best_state_dict = copy.deepcopy(model.state_dict())
+            torch.save(checkpoint, best_checkpoint_path)
+
+        val_matrix = confusion_matrix(val_metrics["preds"], val_metrics["targets"], NUM_CLASSES)
+        print(
+            f"Epoch {epoch:03d}/{args.epochs:03d} "
+            f"train_loss={train_metrics['loss']:.4f} "
+            f"val_loss={val_metrics['loss']:.4f} "
+            f"val_top1={val_metrics['top1']:.4f}"
+        )
+        print(format_confusion_matrix(val_matrix))
+
+    print(f"Best checkpoint: {best_checkpoint_path}")
+    print(f"Last checkpoint: {last_checkpoint_path}")
+
+    if best_state_dict is not None:
+        model.load_state_dict(best_state_dict)
+
+    if test_loader is not None:
+        test_metrics = run_epoch(
+            model=model,
+            loader=test_loader,
+            criterion=criterion,
+            optimizer=None,
+            device=device,
+        )
+        test_matrix = confusion_matrix(test_metrics["preds"], test_metrics["targets"], NUM_CLASSES)
+        print(f"Test top1    : {test_metrics['top1']:.4f}")
+        print(format_confusion_matrix(test_matrix))
+
+    if args.export_onnx:
+        onnx_path = Path(args.onnx_path) if args.onnx_path else output_dir / "best.onnx"
+        export_onnx_model(
+            checkpoint_path=best_checkpoint_path,
+            onnx_path=onnx_path,
+            pretrained=args.pretrained,
+            image_size=MODEL_IMAGE_SIZE,
+            head_hidden_dim=args.head_hidden_dim,
+            dropout=args.dropout,
+        )
+        print(f"ONNX export: {onnx_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/superpowers/plans/2026-05-05-grayscale-a1-5class-training.md
+++ b/docs/superpowers/plans/2026-05-05-grayscale-a1-5class-training.md
@@ -1,0 +1,344 @@
+# Grayscale A1 5-Class Dataset Training Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Convert `demo-rps/dataprocess_modeltrain` to make and train a true grayscale 5-class dataset for `person`, `stop`, `forward`, `obstacle`, and `NoTarget`.
+
+**Architecture:** Keep the existing video-to-image dataset maker and 5-class MobileNetV1 trainer. Dataset images are saved as grayscale, training reads images as single-channel tensors, and the model accepts `1x1x320x320` input without pretrained weights.
+
+**Tech Stack:** Python, OpenCV, PyTorch, torchvision, timm, Pillow, ONNX.
+
+---
+
+## File Structure
+
+- Modify `demo-rps/dataprocess_modeltrain/prepare_video_dataset.py`
+  - Ensure every saved crop is grayscale even if OpenCV returns a 3-channel frame.
+  - Keep class folders fixed to `person`, `stop`, `forward`, `obstacle`, `NoTarget`.
+- Modify `demo-rps/dataprocess_modeltrain/train_a1_5class_classifier.py`
+  - Load images as `L` grayscale.
+  - Normalize using single-channel mean/std.
+  - Build a true 1-channel MobileNetV1 classifier.
+  - Disable pretrained weights by default.
+  - Export ONNX with dummy input shape `1x1x320x320`.
+- Create `demo-rps/dataprocess_modeltrain/requirements.txt`
+  - Record training and dataset dependencies.
+- Optionally update `demo-rps/dataprocess_modeltrain/README.md`
+  - Document grayscale five-class usage and install command.
+
+## Task 1: Add Grayscale Dataset Saving
+
+**Files:**
+- Modify: `demo-rps/dataprocess_modeltrain/prepare_video_dataset.py`
+
+- [ ] **Step 1: Add grayscale conversion helper**
+
+Add this helper after `center_crop`:
+
+```python
+def to_grayscale(frame):
+    if len(frame.shape) == 2:
+        return frame
+    if frame.shape[2] == 1:
+        return frame[:, :, 0]
+    return cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+```
+
+- [ ] **Step 2: Save grayscale crops**
+
+Change `process_video` crop save path from:
+
+```python
+cropped = center_cropped[y1:y2, x1:x2]
+```
+
+to:
+
+```python
+cropped = to_grayscale(center_cropped[y1:y2, x1:x2])
+```
+
+- [ ] **Step 3: Run syntax check**
+
+Run:
+
+```bash
+python -m py_compile demo-rps/dataprocess_modeltrain/prepare_video_dataset.py
+```
+
+Expected: command exits with code `0`.
+
+## Task 2: Convert Trainer To True 1-Channel Input
+
+**Files:**
+- Modify: `demo-rps/dataprocess_modeltrain/train_a1_5class_classifier.py`
+
+- [ ] **Step 1: Change normalization constants**
+
+Change:
+
+```python
+MEAN = [0.485, 0.456, 0.406]
+STD = [0.229, 0.224, 0.225]
+```
+
+to:
+
+```python
+MEAN = [0.5]
+STD = [0.5]
+```
+
+- [ ] **Step 2: Add input channel constant**
+
+After `NUM_CLASSES = len(CLASS_NAMES)`, add:
+
+```python
+INPUT_CHANNELS = 1
+```
+
+- [ ] **Step 3: Make MobileNetV1 accept one channel**
+
+Change `timm.create_model(...)` in `A1Classifier.__init__` from:
+
+```python
+self.backbone = timm.create_model(
+    "mobilenetv1_100",
+    pretrained=pretrained,
+    num_classes=0,
+    global_pool="",
+)
+```
+
+to:
+
+```python
+self.backbone = timm.create_model(
+    "mobilenetv1_100",
+    pretrained=pretrained,
+    num_classes=0,
+    global_pool="",
+    in_chans=INPUT_CHANNELS,
+)
+```
+
+- [ ] **Step 4: Change dummy feature input to one channel**
+
+Change:
+
+```python
+dummy = torch.zeros(1, 3, image_size, image_size)
+```
+
+to:
+
+```python
+dummy = torch.zeros(1, INPUT_CHANNELS, image_size, image_size)
+```
+
+- [ ] **Step 5: Read images as grayscale**
+
+Change:
+
+```python
+image = Image.open(image_path).convert("RGB")
+```
+
+to:
+
+```python
+image = Image.open(image_path).convert("L")
+```
+
+- [ ] **Step 6: Disable pretrained by default**
+
+Change parser line:
+
+```python
+parser.add_argument("--pretrained", action=argparse.BooleanOptionalAction, default=True)
+```
+
+to:
+
+```python
+parser.add_argument("--pretrained", action=argparse.BooleanOptionalAction, default=False)
+```
+
+- [ ] **Step 7: Export ONNX with one-channel dummy input**
+
+Change:
+
+```python
+dummy_input = torch.randn(1, 3, image_size, image_size)
+```
+
+to:
+
+```python
+dummy_input = torch.randn(1, INPUT_CHANNELS, image_size, image_size)
+```
+
+- [ ] **Step 8: Save metadata input channels**
+
+Add this key in `metadata`:
+
+```python
+"input_channels": INPUT_CHANNELS,
+```
+
+- [ ] **Step 9: Print input channels**
+
+After image size print, add:
+
+```python
+print(f"Input chans : {INPUT_CHANNELS}")
+```
+
+- [ ] **Step 10: Run syntax check**
+
+Run:
+
+```bash
+python -m py_compile demo-rps/dataprocess_modeltrain/train_a1_5class_classifier.py
+```
+
+Expected: command exits with code `0`.
+
+## Task 3: Add Requirements File
+
+**Files:**
+- Create: `demo-rps/dataprocess_modeltrain/requirements.txt`
+
+- [ ] **Step 1: Write dependency list**
+
+Create file with:
+
+```txt
+torch
+torchvision
+timm
+opencv-python-headless
+numpy
+Pillow
+onnx
+```
+
+- [ ] **Step 2: Verify installed imports**
+
+Run:
+
+```bash
+python - <<'PY'
+mods = ['cv2', 'onnx', 'torch', 'torchvision', 'timm', 'numpy', 'PIL']
+for mod in mods:
+    __import__(mod)
+    print(f'{mod} OK')
+PY
+```
+
+Expected output includes:
+
+```text
+cv2 OK
+onnx OK
+torch OK
+torchvision OK
+timm OK
+numpy OK
+PIL OK
+```
+
+## Task 4: Update README Usage
+
+**Files:**
+- Modify: `demo-rps/dataprocess_modeltrain/README.md`
+
+- [ ] **Step 1: Update dependency install command**
+
+Use:
+
+```bash
+pip install -r requirements.txt
+```
+
+- [ ] **Step 2: Update class folder docs**
+
+Document input video folders:
+
+```text
+datasets/
+├── person/
+├── stop/
+├── forward/
+├── obstacle/
+└── NoTarget/
+```
+
+Document output image folders:
+
+```text
+processed_dataset/
+├── train/person/
+├── train/stop/
+├── train/forward/
+├── train/obstacle/
+├── train/NoTarget/
+├── val/<class>/
+└── test/<class>/
+```
+
+- [ ] **Step 3: Update model description**
+
+State:
+
+```text
+Input: 1 x 1 x 320 x 320 grayscale tensor
+Output: 5-class logits [person, stop, forward, obstacle, NoTarget]
+Loss: CrossEntropyLoss
+Pretrained: disabled by default
+```
+
+## Task 5: Final Verification
+
+**Files:**
+- Verify only.
+
+- [ ] **Step 1: Compile all changed scripts**
+
+Run:
+
+```bash
+python -m py_compile demo-rps/dataprocess_modeltrain/prepare_video_dataset.py demo-rps/dataprocess_modeltrain/train_a1_5class_classifier.py
+```
+
+Expected: command exits with code `0`.
+
+- [ ] **Step 2: Verify model can construct one-channel input**
+
+Run:
+
+```bash
+python - <<'PY'
+import importlib.util
+from pathlib import Path
+spec = importlib.util.spec_from_file_location('train_a1', Path('demo-rps/dataprocess_modeltrain/train_a1_5class_classifier.py'))
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+model = mod.build_model(False, mod.MODEL_IMAGE_SIZE, 256, 0.2)
+print(mod.INPUT_CHANNELS)
+print(model(torch.zeros(1, 1, mod.MODEL_IMAGE_SIZE, mod.MODEL_IMAGE_SIZE)).shape)
+PY
+```
+
+Expected output:
+
+```text
+1
+torch.Size([1, 5])
+```
+
+## Self-Review
+
+- Spec coverage: five classes, grayscale dataset save, true one-channel model, no pretrained default, requirements file, and verification are covered.
+- Placeholder scan: no placeholders remain.
+- Type consistency: `INPUT_CHANNELS`, `CLASS_NAMES`, `NUM_CLASSES`, and model/export dummy input all use same one-channel design.


### PR DESCRIPTION
## Summary
- Convert dataset prep to save grayscale crops for person/stop/forward/obstacle/NoTarget.
- Switch trainer to true 1-channel MobileNetV1 input with pretrained weights off by default.
- Add local requirements and update usage docs for the grayscale workflow.

## Test Plan
- [x] `python -m py_compile demo-rps/dataprocess_modeltrain/prepare_video_dataset.py demo-rps/dataprocess_modeltrain/train_a1_5class_classifier.py`
- [x] Import check for `cv2`, `onnx`, `torch`, `torchvision`, `timm`, `numpy`, `PIL`
- [x] Built model emits `torch.Size([1, 5])` for `1x1x320x320` input

🤖 Generated with [Claude Code](https://claude.com/claude-code)